### PR TITLE
fix(DOS-FIX): API routes return 302 redirect instead of 401 for unauthenticated requests (from DOS-005 review)

### DIFF
--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -24,6 +24,16 @@ export const authConfig: NextAuthConfig = {
 
       if (isPublicRoute) return true;
 
+      const isProtectedApiRoute =
+        pathname.startsWith("/api/") && !isApiAuthRoute;
+
+      if (isProtectedApiRoute && !isLoggedIn) {
+        return new Response(JSON.stringify({ error: "Unauthorized" }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
       if (!isLoggedIn) return false;
 
       return true;

--- a/src/lib/test-utils/factories.ts
+++ b/src/lib/test-utils/factories.ts
@@ -23,6 +23,7 @@ export function buildUser(overrides: Partial<User> = {}): User {
     id: "user-test-id",
     email: "test@dossier.local",
     name: "Test User",
+    password_hash: null,
     created_at: new Date("2024-01-01"),
     updated_at: new Date("2024-01-01"),
     ...overrides,


### PR DESCRIPTION
## Summary

fix(DOS-FIX): API routes return 302 redirect instead of 401 for unauthenticated requests (from DOS-005 review)

Closes #35

## Validation

- [ ] Code builds successfully
- [ ] Lint passes
- [ ] Typecheck passes
- [ ] Tests pass (if applicable)
- [ ] Matches design direction from product spec