### PR TITLE
feat(DOS-018): Build entity drawer and mention backlinks

### DIFF
--- a/src/app/dossiers/[id]/entities/page.tsx
+++ b/src/app/dossiers/[id]/entities/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { auth } from "@/auth";
 import { EntitiesClient } from "@/components/entities/EntitiesClient";
-import { getEntities } from "@/server/queries/entities";
+import { getEntities, getEntityBacklinks } from "@/server/queries/entities";
 
 export const metadata: Metadata = {
   title: "Entities — Dossier",
@@ -19,7 +19,16 @@ export default async function EntitiesPage({ params }: EntitiesPageProps) {
   }
 
   const { id } = await params;
-  const entities = await getEntities(id, session.user.id);
+  const [entities, entityBacklinks] = await Promise.all([
+    getEntities(id, session.user.id),
+    getEntityBacklinks(id, session.user.id),
+  ]);
 
-  return <EntitiesClient dossierId={id} entities={entities} />;
+  return (
+    <EntitiesClient
+      dossierId={id}
+      entities={entities}
+      entityBacklinks={entityBacklinks}
+    />
+  );
 }

--- a/src/app/dossiers/[id]/sources/[sourceId]/page.tsx
+++ b/src/app/dossiers/[id]/sources/[sourceId]/page.tsx
@@ -3,7 +3,7 @@ import { redirect, notFound } from "next/navigation";
 import { auth } from "@/auth";
 import { getSources, getSourceForReader } from "@/server/queries/sources";
 import { getClaimsForSource } from "@/server/queries/claims";
-import { getEntities, getEntityBacklinks } from "@/server/queries/entities";
+import { getEntities } from "@/server/queries/entities";
 import { SourceReaderClient } from "@/components/sources/SourceReaderClient";
 
 export const metadata: Metadata = {
@@ -24,14 +24,12 @@ export default async function SourceReaderPage({
 
   const { id, sourceId } = await params;
 
-  const [source, allSources, claims, entities, entityBacklinks] =
-    await Promise.all([
-      getSourceForReader(sourceId, id, session.user.id),
-      getSources(id, session.user.id),
-      getClaimsForSource(sourceId, id, session.user.id),
-      getEntities(id, session.user.id),
-      getEntityBacklinks(id, session.user.id),
-    ]);
+  const [source, allSources, claims, entities] = await Promise.all([
+    getSourceForReader(sourceId, id, session.user.id),
+    getSources(id, session.user.id),
+    getClaimsForSource(sourceId, id, session.user.id),
+    getEntities(id, session.user.id),
+  ]);
 
   if (!source) {
     notFound();
@@ -44,7 +42,6 @@ export default async function SourceReaderPage({
       allSources={allSources}
       claims={claims}
       entities={entities}
-      entityBacklinks={entityBacklinks}
     />
   );
 }

--- a/src/app/dossiers/[id]/sources/[sourceId]/page.tsx
+++ b/src/app/dossiers/[id]/sources/[sourceId]/page.tsx
@@ -3,7 +3,7 @@ import { redirect, notFound } from "next/navigation";
 import { auth } from "@/auth";
 import { getSources, getSourceForReader } from "@/server/queries/sources";
 import { getClaimsForSource } from "@/server/queries/claims";
-import { getEntities } from "@/server/queries/entities";
+import { getEntities, getEntityBacklinks } from "@/server/queries/entities";
 import { SourceReaderClient } from "@/components/sources/SourceReaderClient";
 
 export const metadata: Metadata = {
@@ -24,12 +24,14 @@ export default async function SourceReaderPage({
 
   const { id, sourceId } = await params;
 
-  const [source, allSources, claims, entities] = await Promise.all([
-    getSourceForReader(sourceId, id, session.user.id),
-    getSources(id, session.user.id),
-    getClaimsForSource(sourceId, id, session.user.id),
-    getEntities(id, session.user.id),
-  ]);
+  const [source, allSources, claims, entities, entityBacklinks] =
+    await Promise.all([
+      getSourceForReader(sourceId, id, session.user.id),
+      getSources(id, session.user.id),
+      getClaimsForSource(sourceId, id, session.user.id),
+      getEntities(id, session.user.id),
+      getEntityBacklinks(id, session.user.id),
+    ]);
 
   if (!source) {
     notFound();
@@ -42,6 +44,7 @@ export default async function SourceReaderPage({
       allSources={allSources}
       claims={claims}
       entities={entities}
+      entityBacklinks={entityBacklinks}
     />
   );
 }

--- a/src/components/entities/EntitiesClient.tsx
+++ b/src/components/entities/EntitiesClient.tsx
@@ -2,30 +2,48 @@
 
 import { useMemo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import type { EntityListItem } from "@/server/queries/entities";
+import type {
+  EntityBacklinkItem,
+  EntityListItem,
+} from "@/server/queries/entities";
 import { deleteEntity } from "@/server/actions/entities";
 import { EntityChip } from "./EntityChip";
 import { EntityEditorModal } from "./EntityEditorModal";
+import { EntityDetailDrawer } from "./EntityDetailDrawer";
 import { formatEntityAliases } from "@/lib/entities";
 
 interface EntitiesClientProps {
   dossierId: string;
   entities: EntityListItem[];
+  entityBacklinks: EntityBacklinkItem[];
 }
 
-export function EntitiesClient({ dossierId, entities }: EntitiesClientProps) {
+export function EntitiesClient({
+  dossierId,
+  entities,
+  entityBacklinks,
+}: EntitiesClientProps) {
   const router = useRouter();
   const [editorOpen, setEditorOpen] = useState(false);
   const [editingEntityId, setEditingEntityId] = useState<string | null>(null);
+  const [selectedEntityId, setSelectedEntityId] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
   const editingEntity = useMemo(
     () => entities.find((entity) => entity.id === editingEntityId) ?? null,
-    [editingEntityId, entities],
+    [editingEntityId, entities]
+  );
+
+  const selectedEntity = useMemo(
+    () =>
+      entityBacklinks.find((entity) => entity.id === selectedEntityId) ?? null,
+    [entityBacklinks, selectedEntityId]
   );
 
   function handleDelete(id: string) {
-    if (!window.confirm("Delete this entity? Linked references will be removed.")) {
+    if (
+      !window.confirm("Delete this entity? Linked references will be removed.")
+    ) {
       return;
     }
 
@@ -69,7 +87,8 @@ export function EntitiesClient({ dossierId, entities }: EntitiesClientProps) {
                 maxWidth: "none",
               }}
             >
-              {entities.length} reusable reference{entities.length === 1 ? "" : "s"}
+              {entities.length} reusable reference
+              {entities.length === 1 ? "" : "s"}
             </p>
           </div>
 
@@ -106,7 +125,8 @@ export function EntitiesClient({ dossierId, entities }: EntitiesClientProps) {
                 marginBottom: "1rem",
               }}
             >
-              Promote the people, companies, products, locations, institutions, and topics that recur across your research.
+              Promote the people, companies, products, locations, institutions,
+              and topics that recur across your research.
             </p>
             <button
               type="button"
@@ -117,7 +137,13 @@ export function EntitiesClient({ dossierId, entities }: EntitiesClientProps) {
             </button>
           </div>
         ) : (
-          <div style={{ display: "flex", flexDirection: "column", gap: "0.875rem" }}>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "0.875rem",
+            }}
+          >
             {entities.map((entity) => (
               <div
                 key={entity.id}
@@ -139,6 +165,7 @@ export function EntitiesClient({ dossierId, entities }: EntitiesClientProps) {
                         name: entity.name,
                         type: entity.type,
                       }}
+                      onClick={() => setSelectedEntityId(entity.id)}
                     />
 
                     {entity.description && (
@@ -181,15 +208,24 @@ export function EntitiesClient({ dossierId, entities }: EntitiesClientProps) {
                         color: "var(--color-ink-secondary)",
                       }}
                     >
-                      <span>{entity._count.mentions} mention{entity._count.mentions === 1 ? "" : "s"}</span>
-                      <span>{entity._count.claims} claim{entity._count.claims === 1 ? "" : "s"}</span>
+                      <span>
+                        {entity._count.mentions} mention
+                        {entity._count.mentions === 1 ? "" : "s"}
+                      </span>
+                      <span>
+                        {entity._count.claims} claim
+                        {entity._count.claims === 1 ? "" : "s"}
+                      </span>
                       <span>
                         Updated{" "}
-                        {new Date(entity.updated_at).toLocaleDateString("en-US", {
-                          month: "short",
-                          day: "numeric",
-                          year: "numeric",
-                        })}
+                        {new Date(entity.updated_at).toLocaleDateString(
+                          "en-US",
+                          {
+                            month: "short",
+                            day: "numeric",
+                            year: "numeric",
+                          }
+                        )}
                       </span>
                     </div>
                   </div>
@@ -230,6 +266,12 @@ export function EntitiesClient({ dossierId, entities }: EntitiesClientProps) {
           setEditorOpen(false);
           setEditingEntityId(null);
         }}
+      />
+
+      <EntityDetailDrawer
+        dossierId={dossierId}
+        entity={selectedEntity}
+        onClose={() => setSelectedEntityId(null)}
       />
     </>
   );

--- a/src/components/entities/EntityDetailDrawer.tsx
+++ b/src/components/entities/EntityDetailDrawer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useEffect, useId, useMemo, useRef } from "react";
 import Link from "next/link";
+import { createPortal } from "react-dom";
 import type { EntityBacklinkItem } from "@/server/queries/entities";
 import {
   ENTITY_TYPE_LABELS,
@@ -13,67 +14,160 @@ import {
 } from "@/lib/entities";
 import { EntityChip } from "./EntityChip";
 
+interface EntityDetailPreview {
+  id: string;
+  name: string;
+  type: EntityBacklinkItem["type"];
+  description?: string | null;
+  aliases?: string[];
+  importance?: number | null;
+}
+
 interface EntityDetailDrawerProps {
   dossierId: string;
   entity: EntityBacklinkItem | null;
+  entityPreview?: EntityDetailPreview | null;
+  loading?: boolean;
+  open?: boolean;
   onClose: () => void;
+}
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled]):not([type='hidden'])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+function getFocusableElements(container: HTMLElement) {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    .filter((element) => !element.hasAttribute("disabled"))
+    .filter((element) => element.getAttribute("aria-hidden") !== "true");
 }
 
 export function EntityDetailDrawer({
   dossierId,
   entity,
+  entityPreview = null,
+  loading = false,
+  open = entity != null,
   onClose,
 }: EntityDetailDrawerProps) {
+  const descriptionId = useId();
+  const titleId = useId();
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
+  const displayEntity = entity ?? entityPreview;
   const sortedMentions = useMemo(
     () => (entity ? sortEntityMentions(entity.mentions) : []),
     [entity]
   );
 
   useEffect(() => {
-    if (!entity) {
+    if (!open || !displayEntity) {
       return;
     }
 
     const previousOverflow = document.body.style.overflow;
+    restoreFocusRef.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
+        event.preventDefault();
         onClose();
+        return;
+      }
+
+      if (event.key !== "Tab") {
+        return;
+      }
+
+      const dialog = dialogRef.current;
+      if (!dialog) {
+        return;
+      }
+
+      const focusableElements = getFocusableElements(dialog);
+      if (focusableElements.length === 0) {
+        event.preventDefault();
+        dialog.focus();
+        return;
+      }
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+      const activeElement =
+        document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : null;
+      const isFocusInside = !!activeElement && dialog.contains(activeElement);
+
+      if (event.shiftKey) {
+        if (!isFocusInside || activeElement === firstElement) {
+          event.preventDefault();
+          lastElement.focus();
+        }
+        return;
+      }
+
+      if (!isFocusInside || activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
       }
     };
 
     document.body.style.overflow = "hidden";
     document.addEventListener("keydown", handleKeyDown);
 
+    window.requestAnimationFrame(() => {
+      const dialog = dialogRef.current;
+      if (!dialog) {
+        return;
+      }
+
+      const [firstFocusableElement] = getFocusableElements(dialog);
+      (firstFocusableElement ?? dialog).focus();
+    });
+
     return () => {
       document.body.style.overflow = previousOverflow;
       document.removeEventListener("keydown", handleKeyDown);
+      window.requestAnimationFrame(() => {
+        restoreFocusRef.current?.focus();
+      });
     };
-  }, [entity, onClose]);
+  }, [displayEntity, onClose, open]);
 
-  if (!entity) {
+  if (!open || !displayEntity) {
     return null;
   }
 
-  return (
+  return createPortal(
     <>
-      <button
-        type="button"
-        aria-label="Close entity context"
+      <div
+        aria-hidden="true"
         onClick={onClose}
         style={{
           position: "fixed",
           inset: 0,
-          border: "none",
           backgroundColor: "rgba(31, 41, 51, 0.18)",
           cursor: "pointer",
           zIndex: 30,
         }}
       />
 
-      <aside
+      <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
-        aria-label={`${entity.name} context`}
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        tabIndex={-1}
         style={{
           position: "fixed",
           top: 0,
@@ -103,6 +197,7 @@ export function EntityDetailDrawer({
         >
           <div>
             <p
+              id={descriptionId}
               style={{
                 fontFamily: "var(--font-mono)",
                 fontSize: "0.6875rem",
@@ -115,13 +210,15 @@ export function EntityDetailDrawer({
             >
               Entity Context
             </p>
-            <EntityChip
-              entity={{
-                id: entity.id,
-                name: entity.name,
-                type: entity.type,
-              }}
-            />
+            <h2 id={titleId} style={{ margin: 0 }}>
+              <EntityChip
+                entity={{
+                  id: displayEntity.id,
+                  name: displayEntity.name,
+                  type: displayEntity.type,
+                }}
+              />
+            </h2>
           </div>
 
           <button
@@ -136,7 +233,18 @@ export function EntityDetailDrawer({
         </div>
 
         <DrawerSection title="Profile">
-          {entity.description ? (
+          {loading ? (
+            <p
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.75rem",
+                color: "var(--color-ink-secondary)",
+                maxWidth: "none",
+              }}
+            >
+              Loading entity context...
+            </p>
+          ) : displayEntity.description ? (
             <p
               style={{
                 fontFamily: "var(--font-sans)",
@@ -146,7 +254,7 @@ export function EntityDetailDrawer({
                 maxWidth: "none",
               }}
             >
-              {entity.description}
+              {displayEntity.description}
             </p>
           ) : (
             <p
@@ -172,29 +280,43 @@ export function EntityDetailDrawer({
           >
             <DrawerMetaRow
               label="Type"
-              value={ENTITY_TYPE_LABELS[entity.type]}
+              value={ENTITY_TYPE_LABELS[displayEntity.type]}
             />
             <DrawerMetaRow
               label="Aliases"
               value={
-                entity.aliases.length > 0
-                  ? formatEntityAliases(entity.aliases)
+                displayEntity.aliases != null && displayEntity.aliases.length > 0
+                  ? formatEntityAliases(displayEntity.aliases)
                   : "No aliases recorded"
               }
             />
             <DrawerMetaRow
               label="Importance"
               value={
-                entity.importance != null
-                  ? `${entity.importance}/10`
+                displayEntity.importance != null
+                  ? `${displayEntity.importance}/10`
                   : "Not ranked"
               }
             />
           </div>
         </DrawerSection>
 
-        <DrawerSection title="Backlinks" count={sortedMentions.length}>
-          {sortedMentions.length === 0 ? (
+        <DrawerSection
+          title="Backlinks"
+          count={loading ? undefined : sortedMentions.length}
+        >
+          {loading ? (
+            <p
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.75rem",
+                color: "var(--color-ink-secondary)",
+                maxWidth: "none",
+              }}
+            >
+              Loading linked source context...
+            </p>
+          ) : sortedMentions.length === 0 ? (
             <p
               style={{
                 fontFamily: "var(--font-mono)",
@@ -343,8 +465,9 @@ export function EntityDetailDrawer({
             </div>
           )}
         </DrawerSection>
-      </aside>
-    </>
+      </div>
+    </>,
+    document.body
   );
 }
 

--- a/src/components/entities/EntityDetailDrawer.tsx
+++ b/src/components/entities/EntityDetailDrawer.tsx
@@ -1,0 +1,434 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+import Link from "next/link";
+import type { EntityBacklinkItem } from "@/server/queries/entities";
+import {
+  ENTITY_TYPE_LABELS,
+  buildEntityMentionHref,
+  formatEntityAliases,
+  getEntityMentionSnippet,
+  getEntityMentionSource,
+  sortEntityMentions,
+} from "@/lib/entities";
+import { EntityChip } from "./EntityChip";
+
+interface EntityDetailDrawerProps {
+  dossierId: string;
+  entity: EntityBacklinkItem | null;
+  onClose: () => void;
+}
+
+export function EntityDetailDrawer({
+  dossierId,
+  entity,
+  onClose,
+}: EntityDetailDrawerProps) {
+  const sortedMentions = useMemo(
+    () => (entity ? sortEntityMentions(entity.mentions) : []),
+    [entity]
+  );
+
+  useEffect(() => {
+    if (!entity) {
+      return;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    document.body.style.overflow = "hidden";
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [entity, onClose]);
+
+  if (!entity) {
+    return null;
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label="Close entity context"
+        onClick={onClose}
+        style={{
+          position: "fixed",
+          inset: 0,
+          border: "none",
+          backgroundColor: "rgba(31, 41, 51, 0.18)",
+          cursor: "pointer",
+          zIndex: 30,
+        }}
+      />
+
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-label={`${entity.name} context`}
+        style={{
+          position: "fixed",
+          top: 0,
+          right: 0,
+          bottom: 0,
+          width: "min(30rem, 100vw)",
+          backgroundColor: "var(--color-bg-panel)",
+          borderLeft: "var(--border-thin) solid var(--color-border)",
+          boxShadow: "var(--shadow-float)",
+          zIndex: 40,
+          overflowY: "auto",
+        }}
+      >
+        <div
+          style={{
+            position: "sticky",
+            top: 0,
+            zIndex: 1,
+            backgroundColor: "var(--color-bg-panel)",
+            borderBottom: "var(--border-thin) solid var(--color-border)",
+            padding: "0.75rem 1rem",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: "0.75rem",
+          }}
+        >
+          <div>
+            <p
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.6875rem",
+                color: "var(--color-ink-secondary)",
+                letterSpacing: "0.05em",
+                textTransform: "uppercase",
+                marginBottom: "0.25rem",
+                maxWidth: "none",
+              }}
+            >
+              Entity Context
+            </p>
+            <EntityChip
+              entity={{
+                id: entity.id,
+                name: entity.name,
+                type: entity.type,
+              }}
+            />
+          </div>
+
+          <button
+            type="button"
+            className="btn btn-ghost"
+            onClick={onClose}
+            aria-label="Close entity drawer"
+            style={{ padding: "0.125rem 0.375rem", fontSize: "0.75rem" }}
+          >
+            ✕
+          </button>
+        </div>
+
+        <DrawerSection title="Profile">
+          {entity.description ? (
+            <p
+              style={{
+                fontFamily: "var(--font-sans)",
+                fontSize: "0.875rem",
+                color: "var(--color-ink-primary)",
+                lineHeight: 1.6,
+                maxWidth: "none",
+              }}
+            >
+              {entity.description}
+            </p>
+          ) : (
+            <p
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.75rem",
+                color: "var(--color-ink-secondary)",
+                opacity: 0.75,
+                maxWidth: "none",
+              }}
+            >
+              No description recorded yet.
+            </p>
+          )}
+
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "minmax(0, 1fr)",
+              gap: "0.5rem",
+              marginTop: "0.875rem",
+            }}
+          >
+            <DrawerMetaRow
+              label="Type"
+              value={ENTITY_TYPE_LABELS[entity.type]}
+            />
+            <DrawerMetaRow
+              label="Aliases"
+              value={
+                entity.aliases.length > 0
+                  ? formatEntityAliases(entity.aliases)
+                  : "No aliases recorded"
+              }
+            />
+            <DrawerMetaRow
+              label="Importance"
+              value={
+                entity.importance != null
+                  ? `${entity.importance}/10`
+                  : "Not ranked"
+              }
+            />
+          </div>
+        </DrawerSection>
+
+        <DrawerSection title="Backlinks" count={sortedMentions.length}>
+          {sortedMentions.length === 0 ? (
+            <p
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.75rem",
+                color: "var(--color-ink-secondary)",
+                opacity: 0.75,
+                maxWidth: "none",
+              }}
+            >
+              No source context linked yet.
+            </p>
+          ) : (
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "0.625rem",
+              }}
+            >
+              {sortedMentions.map((mention) => {
+                const mentionHref = buildEntityMentionHref(dossierId, mention);
+                const source = getEntityMentionSource(mention);
+                const snippet = getEntityMentionSnippet(mention);
+                const mentionKind = mention.highlight_id
+                  ? "Highlight"
+                  : "Source";
+
+                const content = (
+                  <>
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "space-between",
+                        gap: "0.75rem",
+                        marginBottom: "0.5rem",
+                      }}
+                    >
+                      <div
+                        style={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: "0.5rem",
+                          minWidth: 0,
+                        }}
+                      >
+                        <span
+                          className="chip"
+                          style={{
+                            fontSize: "0.625rem",
+                            padding: "0.0625rem 0.375rem",
+                          }}
+                        >
+                          {mentionKind}
+                        </span>
+                        <span
+                          style={{
+                            fontFamily: "var(--font-sans)",
+                            fontSize: "0.8125rem",
+                            color: "var(--color-ink-primary)",
+                            fontWeight: 500,
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          {source?.title ?? "Linked source"}
+                        </span>
+                      </div>
+                      <span
+                        style={{
+                          fontFamily: "var(--font-mono)",
+                          fontSize: "0.6875rem",
+                          color: "var(--color-accent-ink)",
+                          flexShrink: 0,
+                        }}
+                      >
+                        Open →
+                      </span>
+                    </div>
+
+                    {snippet && (
+                      <p
+                        style={{
+                          fontFamily: "var(--font-sans)",
+                          fontSize: "0.8125rem",
+                          color: "var(--color-ink-primary)",
+                          lineHeight: 1.55,
+                          maxWidth: "none",
+                        }}
+                      >
+                        {snippet}
+                      </p>
+                    )}
+
+                    {mention.highlight?.quote_text && (
+                      <p
+                        style={{
+                          marginTop: "0.5rem",
+                          fontFamily: "var(--font-sans)",
+                          fontSize: "0.75rem",
+                          color: "var(--color-ink-secondary)",
+                          fontStyle: "italic",
+                          lineHeight: 1.5,
+                          maxWidth: "none",
+                        }}
+                      >
+                        &ldquo;
+                        {mention.highlight.quote_text.length > 160
+                          ? `${mention.highlight.quote_text.slice(0, 160)}…`
+                          : mention.highlight.quote_text}
+                        &rdquo;
+                      </p>
+                    )}
+                  </>
+                );
+
+                if (!mentionHref) {
+                  return (
+                    <div
+                      key={mention.id}
+                      className="panel-raised"
+                      style={{ padding: "0.875rem 0.9375rem" }}
+                    >
+                      {content}
+                    </div>
+                  );
+                }
+
+                return (
+                  <Link
+                    key={mention.id}
+                    href={mentionHref}
+                    onClick={onClose}
+                    className="panel-raised"
+                    style={{
+                      display: "block",
+                      padding: "0.875rem 0.9375rem",
+                      textDecoration: "none",
+                    }}
+                  >
+                    {content}
+                  </Link>
+                );
+              })}
+            </div>
+          )}
+        </DrawerSection>
+      </aside>
+    </>
+  );
+}
+
+function DrawerSection({
+  title,
+  count,
+  children,
+}: {
+  title: string;
+  count?: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <section
+      style={{
+        padding: "1rem",
+        borderBottom: "var(--border-thin) solid var(--color-border)",
+      }}
+    >
+      <h3
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: "0.6875rem",
+          fontWeight: 500,
+          color: "var(--color-ink-secondary)",
+          letterSpacing: "0.05em",
+          textTransform: "uppercase",
+          marginBottom: "0.75rem",
+        }}
+      >
+        {title}
+        {count != null && (
+          <span
+            style={{
+              marginLeft: "0.375rem",
+              opacity: 0.7,
+              fontWeight: 400,
+            }}
+          >
+            ({count})
+          </span>
+        )}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+function DrawerMetaRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: React.ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "baseline",
+        gap: "0.75rem",
+      }}
+    >
+      <span
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: "0.6875rem",
+          color: "var(--color-ink-secondary)",
+          flexShrink: 0,
+        }}
+      >
+        {label}
+      </span>
+      <span
+        style={{
+          fontFamily: "var(--font-sans)",
+          fontSize: "0.8125rem",
+          color: "var(--color-ink-primary)",
+          textAlign: "right",
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/src/components/sources/HighlightedText.tsx
+++ b/src/components/sources/HighlightedText.tsx
@@ -12,6 +12,7 @@ interface Highlight {
 interface HighlightedTextProps {
   text: string;
   highlights: Highlight[];
+  activeHighlightId?: string | null;
 }
 
 const LABEL_BG: Record<string, string> = {
@@ -22,16 +23,25 @@ const LABEL_BG: Record<string, string> = {
   quote: "var(--color-highlight-wash)",
 };
 
-export function HighlightedText({ text, highlights }: HighlightedTextProps) {
+export function HighlightedText({
+  text,
+  highlights,
+  activeHighlightId = null,
+}: HighlightedTextProps) {
   const segments = useMemo(() => {
-    if (highlights.length === 0) return [{ text, highlightId: null, label: null }];
+    if (highlights.length === 0)
+      return [{ text, highlightId: null, label: null }];
 
     // Sort by start_offset, then by end_offset descending for nesting
     const sorted = [...highlights].sort(
-      (a, b) => a.start_offset - b.start_offset || b.end_offset - a.end_offset,
+      (a, b) => a.start_offset - b.start_offset || b.end_offset - a.end_offset
     );
 
-    const result: { text: string; highlightId: string | null; label: string | null }[] = [];
+    const result: {
+      text: string;
+      highlightId: string | null;
+      label: string | null;
+    }[] = [];
     let cursor = 0;
 
     for (const hl of sorted) {
@@ -41,7 +51,11 @@ export function HighlightedText({ text, highlights }: HighlightedTextProps) {
         // Truncate overlapping portion — render only the non-overlapping tail
         const adjustedStart = cursor;
         if (adjustedStart >= end) continue;
-        result.push({ text: text.slice(adjustedStart, end), highlightId: hl.id, label: hl.label });
+        result.push({
+          text: text.slice(adjustedStart, end),
+          highlightId: hl.id,
+          label: hl.label,
+        });
         cursor = end;
         continue;
       }
@@ -49,10 +63,18 @@ export function HighlightedText({ text, highlights }: HighlightedTextProps) {
 
       // Add unhighlighted text before this highlight
       if (cursor < start) {
-        result.push({ text: text.slice(cursor, start), highlightId: null, label: null });
+        result.push({
+          text: text.slice(cursor, start),
+          highlightId: null,
+          label: null,
+        });
       }
 
-      result.push({ text: text.slice(start, end), highlightId: hl.id, label: hl.label });
+      result.push({
+        text: text.slice(start, end),
+        highlightId: hl.id,
+        label: hl.label,
+      });
       cursor = end;
     }
 
@@ -72,18 +94,24 @@ export function HighlightedText({ text, highlights }: HighlightedTextProps) {
             key={seg.highlightId}
             data-highlight-id={seg.highlightId}
             style={{
-              backgroundColor: LABEL_BG[seg.label ?? "evidence"] ?? LABEL_BG.evidence,
+              backgroundColor:
+                LABEL_BG[seg.label ?? "evidence"] ?? LABEL_BG.evidence,
               borderBottom: "1.5px solid var(--color-accent-ink)",
               borderRadius: "var(--radius-xs)",
               padding: "0.0625rem 0",
               color: "inherit",
+              boxShadow:
+                seg.highlightId === activeHighlightId
+                  ? "0 0 0 2px rgba(24, 78, 119, 0.18)"
+                  : "none",
+              transition: "box-shadow var(--duration-fast) ease",
             }}
           >
             {seg.text}
           </mark>
         ) : (
           <span key={i}>{seg.text}</span>
-        ),
+        )
       )}
     </>
   );

--- a/src/components/sources/SourceReaderClient.tsx
+++ b/src/components/sources/SourceReaderClient.tsx
@@ -1,20 +1,28 @@
 "use client";
 
-import { useState, useMemo, useRef } from "react";
+import { useEffect, useState, useMemo, useRef } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { EvidenceGutter } from "./EvidenceGutter";
 import { HighlightedText } from "./HighlightedText";
 import { SelectionToolbar } from "./SelectionToolbar";
 import { CreateClaimModal } from "@/components/claims/CreateClaimModal";
-import type { SourceReaderData, SourceListItem } from "@/server/queries/sources";
+import type {
+  SourceReaderData,
+  SourceListItem,
+} from "@/server/queries/sources";
 import type { SourceClaimItem } from "@/server/queries/claims";
-import type { EntityListItem } from "@/server/queries/entities";
+import type {
+  EntityBacklinkItem,
+  EntityListItem,
+} from "@/server/queries/entities";
 import { dedupeById } from "@/lib/entities";
 import { EntityChip } from "@/components/entities/EntityChip";
 import {
   EntityLinkModal,
   type LinkTarget,
 } from "@/components/entities/EntityLinkModal";
+import { EntityDetailDrawer } from "@/components/entities/EntityDetailDrawer";
 
 interface Props {
   dossierId: string;
@@ -22,6 +30,7 @@ interface Props {
   allSources: SourceListItem[];
   claims: SourceClaimItem[];
   entities: EntityListItem[];
+  entityBacklinks: EntityBacklinkItem[];
 }
 
 const TYPE_LABELS: Record<string, string> = {
@@ -82,12 +91,19 @@ export function SourceReaderClient({
   allSources,
   claims,
   entities,
+  entityBacklinks,
 }: Props) {
+  const searchParams = useSearchParams();
   const [inspectorOpen, setInspectorOpen] = useState(true);
   const readingAreaRef = useRef<HTMLDivElement>(null);
   const [claimModalOpen, setClaimModalOpen] = useState(false);
-  const [preselectedHighlightIds, setPreselectedHighlightIds] = useState<string[]>([]);
+  const [preselectedHighlightIds, setPreselectedHighlightIds] = useState<
+    string[]
+  >([]);
   const [entityTarget, setEntityTarget] = useState<LinkTarget | null>(null);
+  const [selectedEntityId, setSelectedEntityId] = useState<string | null>(null);
+
+  const activeHighlightId = searchParams.get("highlight");
 
   const openClaimModal = (highlightId?: string) => {
     setPreselectedHighlightIds(highlightId ? [highlightId] : []);
@@ -126,11 +142,31 @@ export function SourceReaderClient({
       dedupeById([
         ...source.mentions.map((mention) => mention.entity),
         ...source.highlights.flatMap((highlight) =>
-          highlight.mentions.map((mention) => mention.entity),
+          highlight.mentions.map((mention) => mention.entity)
         ),
       ]),
-    [source.highlights, source.mentions],
+    [source.highlights, source.mentions]
   );
+
+  const selectedEntity = useMemo(
+    () =>
+      entityBacklinks.find((entity) => entity.id === selectedEntityId) ?? null,
+    [entityBacklinks, selectedEntityId]
+  );
+
+  useEffect(() => {
+    if (!activeHighlightId) {
+      return;
+    }
+
+    setInspectorOpen(true);
+
+    const target = readingAreaRef.current?.querySelector<HTMLElement>(
+      `[data-highlight-id="${activeHighlightId}"]`
+    );
+
+    target?.scrollIntoView({ behavior: "smooth", block: "center" });
+  }, [activeHighlightId]);
 
   return (
     <div
@@ -193,8 +229,7 @@ export function SourceReaderClient({
                   borderLeft: isActive
                     ? "var(--border-rule) solid var(--color-accent-ink)"
                     : "var(--border-rule) solid transparent",
-                  transition:
-                    "background-color var(--duration-fast) ease",
+                  transition: "background-color var(--duration-fast) ease",
                 }}
               >
                 <span
@@ -224,8 +259,7 @@ export function SourceReaderClient({
                   }}
                 >
                   {TYPE_LABELS[s.type] ?? s.type}
-                  {s._count.highlights > 0 &&
-                    ` · ${s._count.highlights} hl`}
+                  {s._count.highlights > 0 && ` · ${s._count.highlights} hl`}
                 </span>
               </Link>
             );
@@ -253,6 +287,7 @@ export function SourceReaderClient({
           }}
         >
           <article
+            id="source-context"
             style={{
               width: "100%",
               maxWidth: "var(--space-content-max)",
@@ -287,12 +322,9 @@ export function SourceReaderClient({
               }}
             >
               <span
-                className={
-                  STATUS_CHIP_CLASS[source.source_status] ?? "chip"
-                }
+                className={STATUS_CHIP_CLASS[source.source_status] ?? "chip"}
               >
-                {STATUS_LABELS[source.source_status] ??
-                  source.source_status}
+                {STATUS_LABELS[source.source_status] ?? source.source_status}
               </span>
               <span>{TYPE_LABELS[source.type] ?? source.type}</span>
               {source.author && <span>by {source.author}</span>}
@@ -319,6 +351,7 @@ export function SourceReaderClient({
                 <HighlightedText
                   text={source.raw_text}
                   highlights={source.highlights}
+                  activeHighlightId={activeHighlightId}
                 />
                 <SelectionToolbar
                   sourceId={source.id}
@@ -416,12 +449,23 @@ export function SourceReaderClient({
 
         {/* Metadata section */}
         <InspectorSection title="Metadata">
-          <MetaRow label="Type" value={TYPE_LABELS[source.type] ?? source.type} />
-          <MetaRow label="Status" value={STATUS_LABELS[source.source_status] ?? source.source_status} />
+          <MetaRow
+            label="Type"
+            value={TYPE_LABELS[source.type] ?? source.type}
+          />
+          <MetaRow
+            label="Status"
+            value={STATUS_LABELS[source.source_status] ?? source.source_status}
+          />
           {source.author && <MetaRow label="Author" value={source.author} />}
-          {source.publisher && <MetaRow label="Publisher" value={source.publisher} />}
+          {source.publisher && (
+            <MetaRow label="Publisher" value={source.publisher} />
+          )}
           {source.published_at && (
-            <MetaRow label="Published" value={formatDate(source.published_at)} />
+            <MetaRow
+              label="Published"
+              value={formatDate(source.published_at)}
+            />
           )}
           <MetaRow label="Captured" value={formatDate(source.captured_at)} />
           {source.credibility_rating != null && (
@@ -491,10 +535,7 @@ export function SourceReaderClient({
         )}
 
         {/* Highlights section */}
-        <InspectorSection
-          title="Highlights"
-          count={source.highlights.length}
-        >
+        <InspectorSection title="Highlights" count={source.highlights.length}>
           {source.highlights.length === 0 ? (
             <p
               style={{
@@ -515,122 +556,138 @@ export function SourceReaderClient({
                 gap: "0.5rem",
               }}
             >
-              {source.highlights.map((h) => (
-                <div
-                  key={h.id}
-                  style={{
-                    padding: "0.5rem",
-                    borderLeft:
-                      "var(--border-rule) solid var(--color-accent-ink)",
-                    backgroundColor: "var(--color-highlight-wash)",
-                    borderRadius: "0 var(--radius-xs) var(--radius-xs) 0",
-                  }}
-                >
-                  <p
-                    style={{
-                      fontFamily: "var(--font-sans)",
-                      fontSize: "0.8125rem",
-                      color: "var(--color-ink-primary)",
-                      lineHeight: 1.45,
-                      fontStyle: "italic",
-                      maxWidth: "none",
-                    }}
-                  >
-                    &ldquo;
-                    {h.quote_text.length > 120
-                      ? h.quote_text.slice(0, 120) + "…"
-                      : h.quote_text}
-                    &rdquo;
-                  </p>
-                  <div
-                    style={{
-                      display: "flex",
-                      alignItems: "flex-start",
-                      justifyContent: "space-between",
-                      marginTop: "0.25rem",
-                      gap: "0.75rem",
-                    }}
-                  >
-                    <div style={{ minWidth: 0, flex: 1 }}>
-                      <span
-                        style={{
-                          fontFamily: "var(--font-mono)",
-                          fontSize: "0.6875rem",
-                          color: "var(--color-ink-secondary)",
-                        }}
-                      >
-                        {LABEL_LABELS[h.label] ?? h.label}
-                      </span>
+              {source.highlights.map((h) => {
+                const isActiveHighlight = activeHighlightId === h.id;
 
-                      {h.mentions.length > 0 && (
-                        <div
+                return (
+                  <div
+                    key={h.id}
+                    style={{
+                      padding: "0.5rem",
+                      borderLeft:
+                        "var(--border-rule) solid var(--color-accent-ink)",
+                      backgroundColor: "var(--color-highlight-wash)",
+                      borderRadius: "0 var(--radius-xs) var(--radius-xs) 0",
+                      boxShadow: isActiveHighlight
+                        ? "0 0 0 2px rgba(24, 78, 119, 0.14)"
+                        : "none",
+                      transition: "box-shadow var(--duration-fast) ease",
+                    }}
+                  >
+                    <p
+                      style={{
+                        fontFamily: "var(--font-sans)",
+                        fontSize: "0.8125rem",
+                        color: "var(--color-ink-primary)",
+                        lineHeight: 1.45,
+                        fontStyle: "italic",
+                        maxWidth: "none",
+                      }}
+                    >
+                      &ldquo;
+                      {h.quote_text.length > 120
+                        ? h.quote_text.slice(0, 120) + "…"
+                        : h.quote_text}
+                      &rdquo;
+                    </p>
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "flex-start",
+                        justifyContent: "space-between",
+                        marginTop: "0.25rem",
+                        gap: "0.75rem",
+                      }}
+                    >
+                      <div style={{ minWidth: 0, flex: 1 }}>
+                        <span
                           style={{
-                            display: "flex",
-                            flexWrap: "wrap",
-                            gap: "0.375rem",
-                            marginTop: "0.5rem",
+                            fontFamily: "var(--font-mono)",
+                            fontSize: "0.6875rem",
+                            color: "var(--color-ink-secondary)",
                           }}
                         >
-                          {h.mentions.map((mention) => (
-                            <EntityChip
-                              key={mention.id}
-                              entity={mention.entity}
-                              compact
-                            />
-                          ))}
-                        </div>
-                      )}
-                    </div>
+                          {LABEL_LABELS[h.label] ?? h.label}
+                        </span>
 
-                    <div className="flex items-center gap-1.5 shrink-0">
-                      <button
-                        type="button"
-                        onClick={() => openHighlightEntityModal(h.id, h.quote_text)}
-                        style={{
-                          fontFamily: "var(--font-mono)",
-                          fontSize: "0.625rem",
-                          color: "var(--color-accent-ink)",
-                          backgroundColor: "transparent",
-                          border: "none",
-                          cursor: "pointer",
-                          padding: "0.125rem 0.25rem",
-                          borderRadius: "var(--radius-xs)",
-                          letterSpacing: "0.02em",
-                        }}
-                      >
-                        + Entity
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => openClaimModal(h.id)}
-                        style={{
-                          fontFamily: "var(--font-mono)",
-                          fontSize: "0.625rem",
-                          color: "var(--color-accent-ink)",
-                          backgroundColor: "transparent",
-                          border: "none",
-                          cursor: "pointer",
-                          padding: "0.125rem 0.25rem",
-                          borderRadius: "var(--radius-xs)",
-                          letterSpacing: "0.02em",
-                          transition:
-                            "background-color var(--duration-fast) ease",
-                        }}
-                        onMouseEnter={(e) => {
-                          (e.currentTarget as HTMLButtonElement).style.backgroundColor =
-                            "var(--color-bg-selected)";
-                        }}
-                        onMouseLeave={(e) => {
-                          (e.currentTarget as HTMLButtonElement).style.backgroundColor =
-                            "transparent";
-                        }}
-                      >
-                        + Claim
-                      </button>
+                        {h.mentions.length > 0 && (
+                          <div
+                            style={{
+                              display: "flex",
+                              flexWrap: "wrap",
+                              gap: "0.375rem",
+                              marginTop: "0.5rem",
+                            }}
+                          >
+                            {h.mentions.map((mention) => (
+                              <EntityChip
+                                key={mention.id}
+                                entity={mention.entity}
+                                compact
+                                onClick={() =>
+                                  setSelectedEntityId(mention.entity.id)
+                                }
+                              />
+                            ))}
+                          </div>
+                        )}
+                      </div>
+
+                      <div className="flex items-center gap-1.5 shrink-0">
+                        <button
+                          type="button"
+                          onClick={() =>
+                            openHighlightEntityModal(h.id, h.quote_text)
+                          }
+                          style={{
+                            fontFamily: "var(--font-mono)",
+                            fontSize: "0.625rem",
+                            color: "var(--color-accent-ink)",
+                            backgroundColor: "transparent",
+                            border: "none",
+                            cursor: "pointer",
+                            padding: "0.125rem 0.25rem",
+                            borderRadius: "var(--radius-xs)",
+                            letterSpacing: "0.02em",
+                          }}
+                        >
+                          + Entity
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => openClaimModal(h.id)}
+                          style={{
+                            fontFamily: "var(--font-mono)",
+                            fontSize: "0.625rem",
+                            color: "var(--color-accent-ink)",
+                            backgroundColor: "transparent",
+                            border: "none",
+                            cursor: "pointer",
+                            padding: "0.125rem 0.25rem",
+                            borderRadius: "var(--radius-xs)",
+                            letterSpacing: "0.02em",
+                            transition:
+                              "background-color var(--duration-fast) ease",
+                          }}
+                          onMouseEnter={(e) => {
+                            (
+                              e.currentTarget as HTMLButtonElement
+                            ).style.backgroundColor =
+                              "var(--color-bg-selected)";
+                          }}
+                          onMouseLeave={(e) => {
+                            (
+                              e.currentTarget as HTMLButtonElement
+                            ).style.backgroundColor = "transparent";
+                          }}
+                        >
+                          + Claim
+                        </button>
+                      </div>
                     </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           )}
         </InspectorSection>
@@ -701,10 +758,13 @@ export function SourceReaderClient({
                       gap: "0.375rem",
                       marginTop: "0.25rem",
                     }}
-                    >
-                      <span
-                        className={CLAIM_STATUS_CHIP[c.status] ?? "chip"}
-                      style={{ fontSize: "0.625rem", padding: "0.0625rem 0.375rem" }}
+                  >
+                    <span
+                      className={CLAIM_STATUS_CHIP[c.status] ?? "chip"}
+                      style={{
+                        fontSize: "0.625rem",
+                        padding: "0.0625rem 0.375rem",
+                      }}
                     >
                       {CLAIM_STATUS_LABELS[c.status] ?? c.status}
                     </span>
@@ -744,6 +804,9 @@ export function SourceReaderClient({
                           key={claimEntity.entity.id}
                           entity={claimEntity.entity}
                           compact
+                          onClick={() =>
+                            setSelectedEntityId(claimEntity.entity.id)
+                          }
                         />
                       ))}
                     </div>
@@ -754,7 +817,11 @@ export function SourceReaderClient({
                 type="button"
                 className="btn btn-secondary"
                 onClick={() => openClaimModal()}
-                style={{ fontSize: "0.75rem", padding: "0.25rem 0.5rem", alignSelf: "flex-start" }}
+                style={{
+                  fontSize: "0.75rem",
+                  padding: "0.25rem 0.5rem",
+                  alignSelf: "flex-start",
+                }}
               >
                 + Create Claim
               </button>
@@ -763,7 +830,10 @@ export function SourceReaderClient({
         </InspectorSection>
 
         {/* Linked Entities placeholder */}
-        <InspectorSection title="Linked Entities" count={linkedSourceEntities.length}>
+        <InspectorSection
+          title="Linked Entities"
+          count={linkedSourceEntities.length}
+        >
           {linkedSourceEntities.length === 0 ? (
             <p
               style={{
@@ -775,7 +845,8 @@ export function SourceReaderClient({
                 marginBottom: "0.5rem",
               }}
             >
-              No entity links yet. Attach durable references from the source body or a highlight.
+              No entity links yet. Attach durable references from the source
+              body or a highlight.
             </p>
           ) : (
             <div
@@ -787,7 +858,11 @@ export function SourceReaderClient({
               }}
             >
               {linkedSourceEntities.map((entity) => (
-                <EntityChip key={entity.id} entity={entity} />
+                <EntityChip
+                  key={entity.id}
+                  entity={entity}
+                  onClick={() => setSelectedEntityId(entity.id)}
+                />
               ))}
             </div>
           )}
@@ -852,6 +927,12 @@ export function SourceReaderClient({
         target={entityTarget}
         onClose={() => setEntityTarget(null)}
       />
+
+      <EntityDetailDrawer
+        dossierId={dossierId}
+        entity={selectedEntity}
+        onClose={() => setSelectedEntityId(null)}
+      />
     </div>
   );
 }
@@ -903,13 +984,7 @@ function InspectorSection({
   );
 }
 
-function MetaRow({
-  label,
-  value,
-}: {
-  label: string;
-  value: React.ReactNode;
-}) {
+function MetaRow({ label, value }: { label: string; value: React.ReactNode }) {
   return (
     <div
       style={{

--- a/src/components/sources/SourceReaderClient.tsx
+++ b/src/components/sources/SourceReaderClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { EvidenceGutter } from "./EvidenceGutter";
@@ -16,6 +16,7 @@ import type {
   EntityBacklinkItem,
   EntityListItem,
 } from "@/server/queries/entities";
+import { getEntityBacklinkDetail } from "@/server/actions/entities";
 import { dedupeById } from "@/lib/entities";
 import { EntityChip } from "@/components/entities/EntityChip";
 import {
@@ -30,7 +31,15 @@ interface Props {
   allSources: SourceListItem[];
   claims: SourceClaimItem[];
   entities: EntityListItem[];
-  entityBacklinks: EntityBacklinkItem[];
+}
+
+interface EntityDrawerPreview {
+  id: string;
+  name: string;
+  type: EntityListItem["type"];
+  description?: string | null;
+  aliases?: string[];
+  importance?: number | null;
 }
 
 const TYPE_LABELS: Record<string, string> = {
@@ -91,9 +100,9 @@ export function SourceReaderClient({
   allSources,
   claims,
   entities,
-  entityBacklinks,
 }: Props) {
   const searchParams = useSearchParams();
+  const entityRequestIdRef = useRef(0);
   const [inspectorOpen, setInspectorOpen] = useState(true);
   const readingAreaRef = useRef<HTMLDivElement>(null);
   const [claimModalOpen, setClaimModalOpen] = useState(false);
@@ -101,7 +110,12 @@ export function SourceReaderClient({
     string[]
   >([]);
   const [entityTarget, setEntityTarget] = useState<LinkTarget | null>(null);
-  const [selectedEntityId, setSelectedEntityId] = useState<string | null>(null);
+  const [selectedEntity, setSelectedEntity] =
+    useState<EntityBacklinkItem | null>(null);
+  const [selectedEntityPreview, setSelectedEntityPreview] =
+    useState<EntityDrawerPreview | null>(null);
+  const [isEntityDrawerOpen, setIsEntityDrawerOpen] = useState(false);
+  const [isEntityDrawerPending, startEntityDrawerTransition] = useTransition();
 
   const activeHighlightId = searchParams.get("highlight");
 
@@ -148,11 +162,41 @@ export function SourceReaderClient({
     [source.highlights, source.mentions]
   );
 
-  const selectedEntity = useMemo(
-    () =>
-      entityBacklinks.find((entity) => entity.id === selectedEntityId) ?? null,
-    [entityBacklinks, selectedEntityId]
-  );
+  function closeEntityDrawer() {
+    entityRequestIdRef.current += 1;
+    setIsEntityDrawerOpen(false);
+    setSelectedEntity(null);
+    setSelectedEntityPreview(null);
+  }
+
+  function openEntityDrawer(preview: EntityDrawerPreview) {
+    const requestId = entityRequestIdRef.current + 1;
+    entityRequestIdRef.current = requestId;
+
+    setSelectedEntityPreview(preview);
+    setSelectedEntity(null);
+    setIsEntityDrawerOpen(true);
+
+    startEntityDrawerTransition(async () => {
+      const result = await getEntityBacklinkDetail({
+        dossierId,
+        entityId: preview.id,
+      });
+
+      if (entityRequestIdRef.current !== requestId) {
+        return;
+      }
+
+      if ("error" in result) {
+        setIsEntityDrawerOpen(false);
+        setSelectedEntity(null);
+        setSelectedEntityPreview(null);
+        return;
+      }
+
+      setSelectedEntity(result.entity);
+    });
+  }
 
   useEffect(() => {
     if (!activeHighlightId) {
@@ -624,9 +668,7 @@ export function SourceReaderClient({
                                 key={mention.id}
                                 entity={mention.entity}
                                 compact
-                                onClick={() =>
-                                  setSelectedEntityId(mention.entity.id)
-                                }
+                                onClick={() => openEntityDrawer(mention.entity)}
                               />
                             ))}
                           </div>
@@ -805,7 +847,7 @@ export function SourceReaderClient({
                           entity={claimEntity.entity}
                           compact
                           onClick={() =>
-                            setSelectedEntityId(claimEntity.entity.id)
+                            openEntityDrawer(claimEntity.entity)
                           }
                         />
                       ))}
@@ -861,7 +903,7 @@ export function SourceReaderClient({
                 <EntityChip
                   key={entity.id}
                   entity={entity}
-                  onClick={() => setSelectedEntityId(entity.id)}
+                  onClick={() => openEntityDrawer(entity)}
                 />
               ))}
             </div>
@@ -930,8 +972,11 @@ export function SourceReaderClient({
 
       <EntityDetailDrawer
         dossierId={dossierId}
+        open={isEntityDrawerOpen}
         entity={selectedEntity}
-        onClose={() => setSelectedEntityId(null)}
+        entityPreview={selectedEntityPreview}
+        loading={isEntityDrawerPending && selectedEntity == null}
+        onClose={closeEntityDrawer}
       />
     </div>
   );

--- a/src/lib/__tests__/entities.test.ts
+++ b/src/lib/__tests__/entities.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildEntityMentionHref,
   buildContextSnippet,
   dedupeById,
+  getEntityMentionSnippet,
+  getEntityMentionSource,
   parseEntityAliases,
+  sortEntityMentions,
 } from "@/lib/entities";
 
 describe("parseEntityAliases", () => {
@@ -36,10 +40,129 @@ describe("dedupeById", () => {
         { id: "1", name: "First" },
         { id: "2", name: "Second" },
         { id: "1", name: "Duplicate" },
-      ]),
+      ])
     ).toEqual([
       { id: "1", name: "First" },
       { id: "2", name: "Second" },
+    ]);
+  });
+});
+
+describe("entity mention backlinks", () => {
+  const newerSource = {
+    id: "source-newer",
+    title: "Newer Source",
+    captured_at: new Date("2026-03-02T12:00:00Z"),
+  };
+
+  const olderSource = {
+    id: "source-older",
+    title: "Older Source",
+    captured_at: new Date("2026-02-20T12:00:00Z"),
+  };
+
+  it("prefers an explicit source and falls back to the highlight source", () => {
+    expect(
+      getEntityMentionSource({
+        id: "mention-source",
+        source_id: newerSource.id,
+        highlight_id: null,
+        context_snippet: "Explicit source mention",
+        source: newerSource,
+        highlight: null,
+      })
+    ).toEqual(newerSource);
+
+    expect(
+      getEntityMentionSource({
+        id: "mention-highlight",
+        source_id: null,
+        highlight_id: "highlight-1",
+        context_snippet: null,
+        source: null,
+        highlight: {
+          id: "highlight-1",
+          quote_text: "Fallback quote text",
+          source: olderSource,
+        },
+      })
+    ).toEqual(olderSource);
+  });
+
+  it("builds source and highlight hrefs back into evidence", () => {
+    expect(
+      buildEntityMentionHref("dossier-1", {
+        id: "mention-source",
+        source_id: newerSource.id,
+        highlight_id: null,
+        context_snippet: "Explicit source mention",
+        source: newerSource,
+        highlight: null,
+      })
+    ).toBe("/dossiers/dossier-1/sources/source-newer#source-context");
+
+    expect(
+      buildEntityMentionHref("dossier-1", {
+        id: "mention-highlight",
+        source_id: newerSource.id,
+        highlight_id: "highlight-1",
+        context_snippet: "Highlighted source mention",
+        source: newerSource,
+        highlight: {
+          id: "highlight-1",
+          quote_text: "Quoted evidence",
+          source: newerSource,
+        },
+      })
+    ).toBe(
+      "/dossiers/dossier-1/sources/source-newer?highlight=highlight-1#source-context"
+    );
+  });
+
+  it("uses the highlight quote as a snippet fallback", () => {
+    expect(
+      getEntityMentionSnippet({
+        id: "mention-highlight",
+        source_id: newerSource.id,
+        highlight_id: "highlight-1",
+        context_snippet: null,
+        source: newerSource,
+        highlight: {
+          id: "highlight-1",
+          quote_text: "Fallback quote text",
+          source: newerSource,
+        },
+      })
+    ).toBe("Fallback quote text");
+  });
+
+  it("sorts mentions by source recency before stable fallbacks", () => {
+    const mentions = sortEntityMentions([
+      {
+        id: "mention-older",
+        source_id: olderSource.id,
+        highlight_id: null,
+        context_snippet: "Older source mention",
+        source: olderSource,
+        highlight: null,
+      },
+      {
+        id: "mention-newer",
+        source_id: newerSource.id,
+        highlight_id: "highlight-1",
+        context_snippet: "Newer source mention",
+        source: newerSource,
+        highlight: {
+          id: "highlight-1",
+          quote_text: "Quoted evidence",
+          source: newerSource,
+        },
+      },
+    ]);
+
+    expect(mentions.map((mention) => mention.id)).toEqual([
+      "mention-newer",
+      "mention-older",
     ]);
   });
 });

--- a/src/lib/entities.ts
+++ b/src/lib/entities.ts
@@ -24,8 +24,8 @@ export function parseEntityAliases(input: string): string[] {
       input
         .split(/[\n,]/)
         .map((alias) => alias.trim())
-        .filter(Boolean),
-    ),
+        .filter(Boolean)
+    )
   );
 }
 
@@ -35,7 +35,7 @@ export function formatEntityAliases(aliases: string[]): string {
 
 export function buildContextSnippet(
   input: string | null | undefined,
-  maxLength = 180,
+  maxLength = 180
 ): string | null {
   const normalized = input?.replace(/\s+/g, " ").trim();
 
@@ -60,5 +60,102 @@ export function dedupeById<T extends { id: string }>(items: T[]): T[] {
 
     seen.add(item.id);
     return true;
+  });
+}
+
+type MentionSourceLike = {
+  id: string;
+  title: string;
+  captured_at: Date | string;
+};
+
+type MentionHighlightLike = {
+  id: string;
+  quote_text: string;
+  source: MentionSourceLike | null;
+};
+
+export type EntityMentionLike = {
+  id: string;
+  source_id: string | null;
+  highlight_id: string | null;
+  context_snippet: string | null;
+  source: MentionSourceLike | null;
+  highlight: MentionHighlightLike | null;
+};
+
+export function getEntityMentionSource<T extends EntityMentionLike>(
+  mention: T
+): MentionSourceLike | null {
+  return mention.source ?? mention.highlight?.source ?? null;
+}
+
+export function getEntityMentionSnippet<T extends EntityMentionLike>(
+  mention: T,
+  maxLength = 220
+): string | null {
+  return buildContextSnippet(
+    mention.context_snippet ?? mention.highlight?.quote_text,
+    maxLength
+  );
+}
+
+export function buildEntityMentionHref<T extends EntityMentionLike>(
+  dossierId: string,
+  mention: T
+): string | null {
+  const source = getEntityMentionSource(mention);
+
+  if (!source) {
+    return null;
+  }
+
+  const baseHref = `/dossiers/${dossierId}/sources/${source.id}`;
+
+  if (!mention.highlight_id) {
+    return `${baseHref}#source-context`;
+  }
+
+  const searchParams = new URLSearchParams({ highlight: mention.highlight_id });
+  return `${baseHref}?${searchParams.toString()}#source-context`;
+}
+
+function getCapturedAtValue(value: Date | string | null | undefined) {
+  if (!value) {
+    return 0;
+  }
+
+  return new Date(value).getTime();
+}
+
+export function sortEntityMentions<T extends EntityMentionLike>(
+  mentions: T[]
+): T[] {
+  return [...mentions].sort((a, b) => {
+    const sourceTimeDifference =
+      getCapturedAtValue(getEntityMentionSource(b)?.captured_at) -
+      getCapturedAtValue(getEntityMentionSource(a)?.captured_at);
+
+    if (sourceTimeDifference !== 0) {
+      return sourceTimeDifference;
+    }
+
+    const sourceTitleDifference = (
+      getEntityMentionSource(a)?.title ?? ""
+    ).localeCompare(getEntityMentionSource(b)?.title ?? "");
+
+    if (sourceTitleDifference !== 0) {
+      return sourceTitleDifference;
+    }
+
+    if (a.highlight_id && !b.highlight_id) {
+      return -1;
+    }
+
+    if (!a.highlight_id && b.highlight_id) {
+      return 1;
+    }
+
+    return a.id.localeCompare(b.id);
   });
 }

--- a/src/server/actions/entities.ts
+++ b/src/server/actions/entities.ts
@@ -3,6 +3,10 @@
 import { auth } from "@/auth";
 import { buildContextSnippet } from "@/lib/entities";
 import { db } from "@/lib/db";
+import {
+  getEntityBacklink,
+  type EntityBacklinkItem,
+} from "@/server/queries/entities";
 import { revalidatePath } from "next/cache";
 import type { EntityType } from "@prisma/client";
 
@@ -52,6 +56,25 @@ function getTargetCount(input: LinkEntityInput): number {
 
 function revalidateDossierPaths(dossierId: string) {
   revalidatePath(`/dossiers/${dossierId}`, "layout");
+}
+
+export async function getEntityBacklinkDetail(input: {
+  dossierId: string;
+  entityId: string;
+}): Promise<{ error: string } | { entity: EntityBacklinkItem }> {
+  const session = await auth();
+  if (!session?.user?.id) return { error: "You must be signed in." };
+  if (!input.dossierId) return { error: "Dossier ID is required." };
+  if (!input.entityId) return { error: "Entity ID is required." };
+
+  const entity = await getEntityBacklink(
+    input.dossierId,
+    input.entityId,
+    session.user.id,
+  );
+  if (!entity) return { error: "Entity not found." };
+
+  return { entity };
 }
 
 export async function createEntity(

--- a/src/server/queries/entities.ts
+++ b/src/server/queries/entities.ts
@@ -1,5 +1,42 @@
 import { db } from "@/lib/db";
 
+const entityBacklinkSelect = {
+  id: true,
+  name: true,
+  type: true,
+  description: true,
+  aliases: true,
+  importance: true,
+  mentions: {
+    select: {
+      id: true,
+      source_id: true,
+      highlight_id: true,
+      context_snippet: true,
+      source: {
+        select: {
+          id: true,
+          title: true,
+          captured_at: true,
+        },
+      },
+      highlight: {
+        select: {
+          id: true,
+          quote_text: true,
+          source: {
+            select: {
+              id: true,
+              title: true,
+              captured_at: true,
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;
+
 export async function getEntities(dossierId: string, userId: string) {
   return db.entity.findMany({
     where: {
@@ -36,45 +73,25 @@ export async function getEntityBacklinks(dossierId: string, userId: string) {
       dossier: { owner_id: userId },
     },
     orderBy: [{ updated_at: "desc" }, { name: "asc" }],
-    select: {
-      id: true,
-      name: true,
-      type: true,
-      description: true,
-      aliases: true,
-      importance: true,
-      mentions: {
-        select: {
-          id: true,
-          source_id: true,
-          highlight_id: true,
-          context_snippet: true,
-          source: {
-            select: {
-              id: true,
-              title: true,
-              captured_at: true,
-            },
-          },
-          highlight: {
-            select: {
-              id: true,
-              quote_text: true,
-              source: {
-                select: {
-                  id: true,
-                  title: true,
-                  captured_at: true,
-                },
-              },
-            },
-          },
-        },
-      },
-    },
+    select: entityBacklinkSelect,
   });
 }
 
-export type EntityBacklinkItem = Awaited<
-  ReturnType<typeof getEntityBacklinks>
->[number];
+export async function getEntityBacklink(
+  dossierId: string,
+  entityId: string,
+  userId: string,
+) {
+  return db.entity.findFirst({
+    where: {
+      id: entityId,
+      dossier_id: dossierId,
+      dossier: { owner_id: userId },
+    },
+    select: entityBacklinkSelect,
+  });
+}
+
+export type EntityBacklinkItem = NonNullable<
+  Awaited<ReturnType<typeof getEntityBacklink>>
+>;

--- a/src/server/queries/entities.ts
+++ b/src/server/queries/entities.ts
@@ -28,3 +28,53 @@ export async function getEntities(dossierId: string, userId: string) {
 }
 
 export type EntityListItem = Awaited<ReturnType<typeof getEntities>>[number];
+
+export async function getEntityBacklinks(dossierId: string, userId: string) {
+  return db.entity.findMany({
+    where: {
+      dossier_id: dossierId,
+      dossier: { owner_id: userId },
+    },
+    orderBy: [{ updated_at: "desc" }, { name: "asc" }],
+    select: {
+      id: true,
+      name: true,
+      type: true,
+      description: true,
+      aliases: true,
+      importance: true,
+      mentions: {
+        select: {
+          id: true,
+          source_id: true,
+          highlight_id: true,
+          context_snippet: true,
+          source: {
+            select: {
+              id: true,
+              title: true,
+              captured_at: true,
+            },
+          },
+          highlight: {
+            select: {
+              id: true,
+              quote_text: true,
+              source: {
+                select: {
+                  id: true,
+                  title: true,
+                  captured_at: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+}
+
+export type EntityBacklinkItem = Awaited<
+  ReturnType<typeof getEntityBacklinks>
+>[number];


### PR DESCRIPTION
## Summary

- Added a reusable `EntityDetailDrawer` that shows entity profile details, aliases/importance, and a backlink feed of related source and highlight mentions.
- Wired entity backlink data into both the entities index and source reader so clicking an entity chip opens contextual evidence from entity lists, linked entities, highlights, and claim cards.
- Added backlink navigation back into source evidence with source/highlight deep links, plus source reader support for scrolling to the referenced highlight and visually marking the active passage.
- Expanded entity query/utility coverage to fetch backlink context, resolve source/snippet fallbacks, build mention hrefs, sort mentions by recency, and test the new backlink behaviors.

Closes #18

## Validation

- [x] Code builds successfully
- [x] Lint passes
- [x] Typecheck passes
- [ ] Tests pass (if applicable)
- [ ] Matches design direction from product spec
