### PR TITLE
fix(DOS-086): restore dossier navigation and modal centering

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -133,6 +133,14 @@ a:hover {
   text-underline-offset: 2px;
 }
 
+dialog[open] {
+  margin: auto;
+}
+
+dialog::backdrop {
+  background-color: rgba(31, 41, 51, 0.28);
+}
+
 /* ============================================================
    BASE COMPONENT STYLES
    ============================================================ */
@@ -255,6 +263,27 @@ textarea.input {
   border: var(--border-thin) solid var(--color-border);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-panel);
+}
+
+.dossier-row-link {
+  color: inherit;
+  cursor: pointer;
+  transition:
+    background-color var(--duration-fast) ease,
+    color var(--duration-fast) ease;
+}
+
+.dossier-row-link:hover {
+  background-color: var(--color-bg-selected);
+  text-decoration: none;
+}
+
+.dossier-row-link:focus-visible {
+  outline: 2px solid var(--color-accent-ink);
+  outline-offset: -2px;
+  position: relative;
+  z-index: 1;
+  text-decoration: none;
 }
 
 /* ------ Chips ------ */

--- a/src/components/dossiers/DossiersClient.tsx
+++ b/src/components/dossiers/DossiersClient.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { NewDossierModal } from "./NewDossierModal";
 import type { DossierListItem } from "@/server/queries/dossiers";
@@ -46,8 +47,10 @@ export function DossiersClient({ dossiers }: DossiersClientProps) {
           style={{ overflow: "hidden" }}
         >
           {dossiers.map((dossier, i) => (
-            <div
+            <Link
               key={dossier.id}
+              href={`/dossiers/${dossier.id}/overview`}
+              className="dossier-row-link"
               style={{
                 padding: "1rem 1.25rem",
                 display: "flex",
@@ -58,6 +61,7 @@ export function DossiersClient({ dossiers }: DossiersClientProps) {
                   i < dossiers.length - 1
                     ? "var(--border-thin) solid var(--color-border)"
                     : undefined,
+                textDecoration: "none",
               }}
             >
               <div style={{ minWidth: 0 }}>
@@ -132,7 +136,7 @@ export function DossiersClient({ dossiers }: DossiersClientProps) {
                   {STATUS_LABEL[dossier.status] ?? dossier.status}
                 </span>
               </div>
-            </div>
+            </Link>
           ))}
         </div>
       )}


### PR DESCRIPTION
## Summary
- make dossier list rows navigate to the dossier overview
- restore native dialog centering after the global reset removed default margins
- add hover/focus styling for dossier rows and a shared modal backdrop

## Testing
- npm run lint
- npm run typecheck
- npm run test

Closes #86