### PR TITLE
fix(DOS-086): add comprehensive test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Generate Prisma client
+        run: npx prisma generate
+
       - name: Lint
         run: npm run lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Run tests
+        run: npm run test

--- a/src/app/api/sources/prefetch-url/route.test.ts
+++ b/src/app/api/sources/prefetch-url/route.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mockAuth, mockAuthenticatedUser, resetTestMocks } from "@/test/mocks";
+
+const { mockValidateUrlForFetch } = vi.hoisted(() => ({
+  mockValidateUrlForFetch: vi.fn(),
+}));
+
+vi.mock("@/auth", () => ({ auth: mockAuth }));
+vi.mock("@/lib/ssrf", () => ({ validateUrlForFetch: mockValidateUrlForFetch }));
+
+import { POST } from "./route";
+
+describe("POST /api/sources/prefetch-url", () => {
+  beforeEach(() => {
+    resetTestMocks();
+    mockValidateUrlForFetch.mockReset();
+    mockValidateUrlForFetch.mockResolvedValue({ safe: true });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    const response = await POST({
+      json: vi.fn(),
+    } as never);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+  });
+
+  it("rejects invalid JSON payloads", async () => {
+    mockAuthenticatedUser();
+
+    const response = await POST({
+      json: vi.fn().mockRejectedValue(new Error("bad json")),
+    } as never);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid request body",
+    });
+  });
+
+  it("requires a URL", async () => {
+    mockAuthenticatedUser();
+
+    const response = await POST({
+      json: vi.fn().mockResolvedValue({}),
+    } as never);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "URL is required" });
+  });
+
+  it("rejects malformed URLs", async () => {
+    mockAuthenticatedUser();
+
+    const response = await POST({
+      json: vi.fn().mockResolvedValue({ url: "not-a-url" }),
+    } as never);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid URL" });
+  });
+
+  it("rejects SSRF-blocked URLs", async () => {
+    mockAuthenticatedUser();
+    mockValidateUrlForFetch.mockResolvedValue({
+      safe: false,
+      reason: "URL resolves to a blocked address",
+    });
+
+    const response = await POST({
+      json: vi.fn().mockResolvedValue({ url: "https://example.com" }),
+    } as never);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "URL resolves to a blocked address",
+    });
+  });
+
+  it("returns a null title for non-success responses", async () => {
+    mockAuthenticatedUser();
+    const fetchMock = vi.fn().mockResolvedValue(new Response("nope", { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await POST({
+      json: vi.fn().mockResolvedValue({ url: "https://example.com" }),
+    } as never);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ title: null });
+  });
+
+  it("returns a null title for non-html responses", async () => {
+    mockAuthenticatedUser();
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await POST({
+      json: vi.fn().mockResolvedValue({ url: "https://example.com" }),
+    } as never);
+
+    await expect(response.json()).resolves.toEqual({ title: null });
+  });
+
+  it("extracts and trims the document title", async () => {
+    mockAuthenticatedUser();
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        "<html><head><title>  Example   Title </title></head><body /></html>",
+        {
+          status: 200,
+          headers: { "content-type": "text/html; charset=utf-8" },
+        },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await POST({
+      json: vi.fn().mockResolvedValue({ url: "https://example.com" }),
+    } as never);
+
+    await expect(response.json()).resolves.toEqual({ title: "Example Title" });
+  });
+
+  it("returns a null title when the response body is unavailable", async () => {
+    mockAuthenticatedUser();
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(null, {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await POST({
+      json: vi.fn().mockResolvedValue({ url: "https://example.com" }),
+    } as never);
+
+    await expect(response.json()).resolves.toEqual({ title: null });
+  });
+
+  it("returns a null title when the network request fails", async () => {
+    mockAuthenticatedUser();
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await POST({
+      json: vi.fn().mockResolvedValue({ url: "https://example.com" }),
+    } as never);
+
+    await expect(response.json()).resolves.toEqual({ title: null });
+  });
+});

--- a/src/app/api/sources/upload/route.test.ts
+++ b/src/app/api/sources/upload/route.test.ts
@@ -1,0 +1,306 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockAuth,
+  mockAuthenticatedUser,
+  mockDb,
+  resetTestMocks,
+} from "@/test/mocks";
+
+const {
+  mockSaveUploadedFile,
+  mockDeleteStoredFile,
+  mockPdfGetText,
+  mockPdfDestroy,
+  mockPDFParse,
+} = vi.hoisted(() => {
+  const mockPdfGetText = vi.fn();
+  const mockPdfDestroy = vi.fn();
+
+  return {
+    mockSaveUploadedFile: vi.fn(),
+    mockDeleteStoredFile: vi.fn(),
+    mockPdfGetText,
+    mockPdfDestroy,
+    mockPDFParse: vi.fn(() => ({
+      getText: mockPdfGetText,
+      destroy: mockPdfDestroy,
+    })),
+  };
+});
+
+vi.mock("@/auth", () => ({ auth: mockAuth }));
+vi.mock("@/lib/db", () => ({ db: mockDb }));
+vi.mock("@/lib/storage", () => ({
+  saveUploadedFile: mockSaveUploadedFile,
+  deleteStoredFile: mockDeleteStoredFile,
+}));
+vi.mock("pdf-parse", () => ({ PDFParse: mockPDFParse }));
+
+import { POST } from "./route";
+
+describe("POST /api/sources/upload", () => {
+  beforeEach(() => {
+    resetTestMocks();
+    mockSaveUploadedFile.mockReset();
+    mockDeleteStoredFile.mockReset();
+    mockPdfGetText.mockReset();
+    mockPdfDestroy.mockReset();
+    mockPDFParse.mockClear();
+    mockSaveUploadedFile.mockResolvedValue({
+      filePath: "sources/file.txt",
+      fileName: "note.txt",
+      fileSize: 12,
+    });
+    mockPdfGetText.mockResolvedValue({ text: "PDF text" });
+  });
+
+  function buildRequest(formData: FormData) {
+    return {
+      formData: vi.fn().mockResolvedValue(formData),
+    } as never;
+  }
+
+  function createUploadFile(contents: string, name: string, type: string) {
+    const file = new File([contents], name, { type });
+    Object.defineProperty(file, "arrayBuffer", {
+      value: vi.fn().mockResolvedValue(new TextEncoder().encode(contents).buffer),
+    });
+    return file;
+  }
+
+  function buildFormData(file?: File, extras: Record<string, string> = {}) {
+    const values = new Map<string, string | File>();
+    if (file) {
+      values.set("file", file);
+    }
+    Object.entries(extras).forEach(([key, value]) => {
+      values.set(key, value);
+    });
+    return {
+      get(key: string) {
+        return values.get(key) ?? null;
+      },
+    } as FormData;
+  }
+
+  it("rejects unauthenticated requests", async () => {
+    const response = await POST(buildRequest(new FormData()));
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+  });
+
+  it("rejects invalid form data", async () => {
+    mockAuthenticatedUser();
+
+    const response = await POST({
+      formData: vi.fn().mockRejectedValue(new Error("bad form")),
+    } as never);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid form data.",
+    });
+  });
+
+  it("requires a file, dossier id, and title", async () => {
+    mockAuthenticatedUser();
+
+    const missingFile = await POST(
+      buildRequest(buildFormData(undefined, { dossierId: "dos-1", title: "Source" })),
+    );
+    await expect(missingFile.json()).resolves.toEqual({
+      error: "File is required.",
+    });
+
+    const missingDossier = await POST(
+      buildRequest(
+        buildFormData(new File(["hello"], "note.txt", { type: "text/plain" }), {
+          title: "Source",
+        }),
+      ),
+    );
+    await expect(missingDossier.json()).resolves.toEqual({
+      error: "Dossier ID is required.",
+    });
+
+    const missingTitle = await POST(
+      buildRequest(
+        buildFormData(new File(["hello"], "note.txt", { type: "text/plain" }), {
+          dossierId: "dos-1",
+        }),
+      ),
+    );
+    await expect(missingTitle.json()).resolves.toEqual({
+      error: "Title is required.",
+    });
+  });
+
+  it("rejects unsupported file types", async () => {
+    mockAuthenticatedUser();
+
+    const response = await POST(
+      buildRequest(
+        buildFormData(new File(["{}"], "data.json", { type: "application/json" }), {
+          dossierId: "dos-1",
+          title: "Source",
+        }),
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Unsupported file type. Only PDF and plain text files are accepted.",
+    });
+  });
+
+  it("rejects oversized files", async () => {
+    mockAuthenticatedUser();
+    const file = new File(["x"], "note.txt", { type: "text/plain" });
+    Object.defineProperty(file, "size", { value: 20 * 1024 * 1024 + 1 });
+
+    const response = await POST(
+      buildRequest(
+        buildFormData(file, {
+          dossierId: "dos-1",
+          title: "Source",
+        }),
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "File is too large. Maximum size is 20 MB.",
+    });
+  });
+
+  it("rejects dossiers outside the current account", async () => {
+    mockAuthenticatedUser();
+    mockDb.dossier.findFirst.mockResolvedValue(null);
+
+    const response = await POST(
+      buildRequest(
+        buildFormData(new File(["hello"], "note.txt", { type: "text/plain" }), {
+          dossierId: "dos-1",
+          title: "Source",
+        }),
+      ),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Dossier not found." });
+  });
+
+  it("creates plain-text sources after saving the uploaded file", async () => {
+    mockAuthenticatedUser();
+    mockDb.dossier.findFirst.mockResolvedValue({ id: "dos-1" });
+    mockDb.source.create.mockResolvedValue({ id: "source-1" });
+
+    const response = await POST(
+      buildRequest(
+        buildFormData(createUploadFile("hello world", "note.txt", "text/plain"), {
+          dossierId: "dos-1",
+          title: "Source",
+        }),
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ id: "source-1" });
+    expect(mockSaveUploadedFile).toHaveBeenCalledTimes(1);
+    expect(mockDb.source.create).toHaveBeenCalledWith({
+      data: {
+        dossier_id: "dos-1",
+        type: "pasted_text",
+        title: "Source",
+        raw_text: "hello world",
+        file_path: "sources/file.txt",
+        file_name: "note.txt",
+        file_size: 12,
+        source_status: "unreviewed",
+      },
+    });
+  });
+
+  it("extracts PDF text before saving and creating the source", async () => {
+    mockAuthenticatedUser();
+    mockDb.dossier.findFirst.mockResolvedValue({ id: "dos-1" });
+    mockDb.source.create.mockResolvedValue({ id: "source-1" });
+
+    const response = await POST(
+      buildRequest(
+        buildFormData(createUploadFile("%PDF", "file.pdf", "application/pdf"), {
+          dossierId: "dos-1",
+          title: "Source",
+        }),
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockPDFParse).toHaveBeenCalledTimes(1);
+    expect(mockPdfDestroy).toHaveBeenCalledTimes(1);
+    await expect(response.json()).resolves.toEqual({ id: "source-1" });
+  });
+
+  it("returns 422 when text extraction fails", async () => {
+    mockAuthenticatedUser();
+    mockDb.dossier.findFirst.mockResolvedValue({ id: "dos-1" });
+    mockPdfGetText.mockRejectedValue(new Error("parse failed"));
+
+    const response = await POST(
+      buildRequest(
+        buildFormData(createUploadFile("%PDF", "file.pdf", "application/pdf"), {
+          dossierId: "dos-1",
+          title: "Source",
+        }),
+      ),
+    );
+
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toEqual({
+      error: "Failed to extract text from the uploaded file.",
+    });
+    expect(mockSaveUploadedFile).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when saving the file fails", async () => {
+    mockAuthenticatedUser();
+    mockDb.dossier.findFirst.mockResolvedValue({ id: "dos-1" });
+    mockSaveUploadedFile.mockRejectedValue(new Error("save failed"));
+
+    const response = await POST(
+      buildRequest(
+        buildFormData(createUploadFile("hello", "note.txt", "text/plain"), {
+          dossierId: "dos-1",
+          title: "Source",
+        }),
+      ),
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "Failed to save file. Please try again.",
+    });
+  });
+
+  it("cleans up stored files when database insertion fails", async () => {
+    mockAuthenticatedUser();
+    mockDb.dossier.findFirst.mockResolvedValue({ id: "dos-1" });
+    mockDb.source.create.mockRejectedValue(new Error("db failed"));
+
+    const response = await POST(
+      buildRequest(
+        buildFormData(createUploadFile("hello", "note.txt", "text/plain"), {
+          dossierId: "dos-1",
+          title: "Source",
+        }),
+      ),
+    );
+
+    expect(response.status).toBe(500);
+    expect(mockDeleteStoredFile).toHaveBeenCalledWith("sources/file.txt");
+    await expect(response.json()).resolves.toEqual({
+      error: "Failed to create source. Please try again.",
+    });
+  });
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -133,6 +133,14 @@ a:hover {
   text-underline-offset: 2px;
 }
 
+dialog[open] {
+  margin: auto;
+}
+
+dialog::backdrop {
+  background-color: rgba(31, 41, 51, 0.28);
+}
+
 /* ============================================================
    BASE COMPONENT STYLES
    ============================================================ */
@@ -255,6 +263,27 @@ textarea.input {
   border: var(--border-thin) solid var(--color-border);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-panel);
+}
+
+.dossier-row-link {
+  color: inherit;
+  cursor: pointer;
+  transition:
+    background-color var(--duration-fast) ease,
+    color var(--duration-fast) ease;
+}
+
+.dossier-row-link:hover {
+  background-color: var(--color-bg-selected);
+  text-decoration: none;
+}
+
+.dossier-row-link:focus-visible {
+  outline: 2px solid var(--color-accent-ink);
+  outline-offset: -2px;
+  position: relative;
+  z-index: 1;
+  text-decoration: none;
 }
 
 /* ------ Chips ------ */

--- a/src/auth.config.test.ts
+++ b/src/auth.config.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { authConfig } from "@/auth.config";
+
+describe("authConfig.callbacks.authorized", () => {
+  const authorized = authConfig.callbacks?.authorized;
+
+  if (!authorized) {
+    throw new Error("authorized callback is required");
+  }
+
+  function buildContext(pathname: string, signedIn = false) {
+    return {
+      auth: signedIn
+        ? ({ user: { id: "user-1" }, expires: "2099-01-01T00:00:00.000Z" } as never)
+        : null,
+      request: {
+        nextUrl: new URL(`http://localhost${pathname}`) as never,
+      } as never,
+    } as never;
+  }
+
+  it("allows auth API routes without a session", async () => {
+    const result = await authorized(buildContext("/api/auth/session"));
+
+    expect(result).toBe(true);
+  });
+
+  it("redirects signed-in users away from auth pages", async () => {
+    const result = await authorized(buildContext("/login", true));
+
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).headers.get("location")).toBe(
+      "http://localhost/dossiers",
+    );
+  });
+
+  it("allows public routes without a session", async () => {
+    const result = await authorized(buildContext("/"));
+
+    expect(result).toBe(true);
+  });
+
+  it("returns a JSON 401 response for protected API routes without a session", async () => {
+    const result = await authorized(buildContext("/api/sources/upload"));
+
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(401);
+    await expect((result as Response).json()).resolves.toEqual({
+      error: "Unauthorized",
+    });
+  });
+
+  it("rejects protected pages without a session", async () => {
+    const result = await authorized(buildContext("/dossiers"));
+
+    expect(result).toBe(false);
+  });
+
+  it("allows protected pages with a session", async () => {
+    const result = await authorized(buildContext("/dossiers", true));
+
+    expect(result).toBe(true);
+  });
+});

--- a/src/components/claims/CreateClaimModal.test.tsx
+++ b/src/components/claims/CreateClaimModal.test.tsx
@@ -1,0 +1,108 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockRouterRefresh,
+  mockUseRouter,
+  resetTestMocks,
+} from "@/test/mocks";
+
+const { mockCreateClaim } = vi.hoisted(() => ({
+  mockCreateClaim: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({ useRouter: mockUseRouter }));
+vi.mock("@/server/actions/claims", () => ({ createClaim: mockCreateClaim }));
+
+import { CreateClaimModal } from "./CreateClaimModal";
+
+describe("CreateClaimModal", () => {
+  beforeEach(() => {
+    cleanup();
+    resetTestMocks();
+    mockCreateClaim.mockReset();
+    mockCreateClaim.mockResolvedValue({ id: "claim-1" });
+  });
+
+  const highlights = [
+    { id: "hl-1", quote_text: "First quote", label: "evidence" },
+    { id: "hl-2", quote_text: "Second quote", label: "question" },
+  ];
+
+  it("submits the selected highlights and numeric confidence", async () => {
+    const onClose = vi.fn();
+
+    render(
+      <CreateClaimModal
+        dossierId="dos-1"
+        highlights={highlights}
+        preselectedHighlightIds={["hl-1"]}
+        open
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "A clear, defensible assertion drawn from evidence...",
+      ),
+      {
+      target: { value: "This evidence supports the claim." },
+      },
+    );
+    fireEvent.change(screen.getByPlaceholderText("—"), {
+      target: { value: "75" },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText("Optional context or reasoning..."),
+      {
+      target: { value: "Supporting context" },
+      },
+    );
+    fireEvent.click(screen.getByRole("button", { name: /second quote/i }));
+    fireEvent.submit(screen.getByRole("button", { name: "Create Claim" }).closest("form")!);
+
+    await waitFor(() => {
+      expect(mockCreateClaim).toHaveBeenCalledWith({
+        dossierId: "dos-1",
+        statement: "This evidence supports the claim.",
+        status: "open",
+        confidence: 75,
+        notes: "Supporting context",
+        highlightIds: ["hl-1", "hl-2"],
+      });
+    });
+    expect(mockRouterRefresh).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("shows action errors without closing the modal", async () => {
+    const onClose = vi.fn();
+    mockCreateClaim.mockResolvedValue({ error: "At least one highlight is required." });
+
+    render(
+      <CreateClaimModal dossierId="dos-1" highlights={highlights} open onClose={onClose} />,
+    );
+
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "A clear, defensible assertion drawn from evidence...",
+      ),
+      {
+      target: { value: "This evidence supports the claim." },
+      },
+    );
+    fireEvent.submit(screen.getByRole("button", { name: "Create Claim" }).closest("form")!);
+
+    expect(
+      await screen.findByText("At least one highlight is required."),
+    ).toBeInTheDocument();
+    expect(mockRouterRefresh).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/dossiers/DossiersClient.tsx
+++ b/src/components/dossiers/DossiersClient.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { NewDossierModal } from "./NewDossierModal";
 import type { DossierListItem } from "@/server/queries/dossiers";
@@ -46,8 +47,10 @@ export function DossiersClient({ dossiers }: DossiersClientProps) {
           style={{ overflow: "hidden" }}
         >
           {dossiers.map((dossier, i) => (
-            <div
+            <Link
               key={dossier.id}
+              href={`/dossiers/${dossier.id}/overview`}
+              className="dossier-row-link"
               style={{
                 padding: "1rem 1.25rem",
                 display: "flex",
@@ -58,6 +61,7 @@ export function DossiersClient({ dossiers }: DossiersClientProps) {
                   i < dossiers.length - 1
                     ? "var(--border-thin) solid var(--color-border)"
                     : undefined,
+                textDecoration: "none",
               }}
             >
               <div style={{ minWidth: 0 }}>
@@ -132,7 +136,7 @@ export function DossiersClient({ dossiers }: DossiersClientProps) {
                   {STATUS_LABEL[dossier.status] ?? dossier.status}
                 </span>
               </div>
-            </div>
+            </Link>
           ))}
         </div>
       )}

--- a/src/components/entities/EntityEditorModal.test.tsx
+++ b/src/components/entities/EntityEditorModal.test.tsx
@@ -1,0 +1,127 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockRouterRefresh,
+  mockUseRouter,
+  resetTestMocks,
+} from "@/test/mocks";
+
+const { mockCreateEntity, mockUpdateEntity } = vi.hoisted(() => ({
+  mockCreateEntity: vi.fn(),
+  mockUpdateEntity: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({ useRouter: mockUseRouter }));
+vi.mock("@/server/actions/entities", () => ({
+  createEntity: mockCreateEntity,
+  updateEntity: mockUpdateEntity,
+}));
+
+import { EntityEditorModal } from "./EntityEditorModal";
+
+describe("EntityEditorModal", () => {
+  beforeEach(() => {
+    cleanup();
+    resetTestMocks();
+    mockCreateEntity.mockReset();
+    mockUpdateEntity.mockReset();
+    mockCreateEntity.mockResolvedValue({ id: "entity-1" });
+    mockUpdateEntity.mockResolvedValue({ success: true });
+  });
+
+  it("creates entities with parsed aliases", async () => {
+    const onClose = vi.fn();
+
+    render(
+      <EntityEditorModal dossierId="dos-1" open onClose={onClose} />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/name/i), {
+      target: { value: "Northgate Pharma" },
+    });
+    fireEvent.change(screen.getByLabelText(/type/i), {
+      target: { value: "company" },
+    });
+    fireEvent.change(screen.getByLabelText(/description/i), {
+      target: { value: "Key manufacturer" },
+    });
+    fireEvent.change(screen.getByLabelText(/aliases/i), {
+      target: { value: "Northgate\nNGP, Northgate" },
+    });
+
+    fireEvent.submit(screen.getByRole("button", { name: "Create Entity" }).closest("form")!);
+
+    await waitFor(() => {
+      expect(mockCreateEntity).toHaveBeenCalledWith({
+        dossierId: "dos-1",
+        name: "Northgate Pharma",
+        type: "company",
+        description: "Key manufacturer",
+        aliases: ["Northgate", "NGP"],
+      });
+    });
+    expect(mockRouterRefresh).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("updates an existing entity", async () => {
+    const onClose = vi.fn();
+
+    render(
+      <EntityEditorModal
+        dossierId="dos-1"
+        entity={{
+          id: "entity-1",
+          name: "Northgate",
+          type: "company",
+          description: "Old description",
+          aliases: ["NG"],
+        }}
+        open
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/description/i), {
+      target: { value: "Updated description" },
+    });
+    expect(screen.getByDisplayValue("Updated description")).toBeInTheDocument();
+    fireEvent.submit(screen.getByRole("button", { name: "Save Entity" }).closest("form")!);
+
+    await waitFor(() => {
+      expect(mockUpdateEntity).toHaveBeenCalledWith({
+        id: "entity-1",
+        name: "Northgate",
+        type: "company",
+        description: "Updated description",
+        aliases: ["NG"],
+      });
+    });
+    expect(mockRouterRefresh).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("shows action errors without closing the modal", async () => {
+    const onClose = vi.fn();
+    mockCreateEntity.mockResolvedValue({ error: "Entity already exists." });
+
+    render(
+      <EntityEditorModal dossierId="dos-1" open onClose={onClose} />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/name/i), {
+      target: { value: "Northgate" },
+    });
+    fireEvent.submit(screen.getByRole("button", { name: "Create Entity" }).closest("form")!);
+
+    expect(await screen.findByText("Entity already exists.")).toBeInTheDocument();
+    expect(mockRouterRefresh).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/sources/HighlightedText.test.tsx
+++ b/src/components/sources/HighlightedText.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { HighlightedText } from "./HighlightedText";
+
+describe("HighlightedText", () => {
+  it("renders plain text when there are no highlights", () => {
+    render(<HighlightedText text="Analyst brief" highlights={[]} />);
+
+    expect(screen.getByText("Analyst brief")).toBeInTheDocument();
+    expect(screen.queryByText("Analyst brief")?.tagName).toBe("SPAN");
+  });
+
+  it("renders highlight segments and truncates overlaps to non-overlapping tails", () => {
+    render(
+      <HighlightedText
+        text="abcdefghi"
+        highlights={[
+          { id: "one", start_offset: 1, end_offset: 5, label: "evidence" },
+          { id: "two", start_offset: 3, end_offset: 8, label: "quote" },
+        ]}
+      />,
+    );
+
+    const firstMark = screen.getByText("bcde");
+    const secondMark = screen.getByText("fgh");
+
+    expect(firstMark).toHaveAttribute("data-highlight-id", "one");
+    expect(secondMark).toHaveAttribute("data-highlight-id", "two");
+    expect(screen.getByText("a")).toBeInTheDocument();
+    expect(screen.getByText("i")).toBeInTheDocument();
+  });
+});

--- a/src/components/sources/SourceStatusMenu.test.tsx
+++ b/src/components/sources/SourceStatusMenu.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@radix-ui/react-dropdown-menu", () => ({
+  Root: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Trigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  Portal: ({ children }: { children: ReactNode }) => <>{children}</>,
+  Content: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Item: ({
+    children,
+    onSelect,
+  }: {
+    children: ReactNode;
+    onSelect?: () => void;
+  }) => <button onClick={onSelect}>{children}</button>,
+}));
+
+import { SourceStatusMenu } from "./SourceStatusMenu";
+
+describe("SourceStatusMenu", () => {
+  it("hides the current status and sends the selected next status", async () => {
+    const onStatusChange = vi.fn();
+
+    render(
+      <SourceStatusMenu
+        sourceId="source-1"
+        currentStatus="reviewing"
+        onStatusChange={onStatusChange}
+      />,
+    );
+
+    expect(screen.queryByText("Mark reviewing")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Mark reviewed"));
+
+    expect(onStatusChange).toHaveBeenCalledWith("source-1", "reviewed");
+  });
+});

--- a/src/server/actions/__tests__/auth.test.ts
+++ b/src/server/actions/__tests__/auth.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockDb,
+  mockSignIn,
+  resetTestMocks,
+} from "@/test/mocks";
+
+const { MockAuthError } = vi.hoisted(() => ({
+  MockAuthError: class MockAuthError extends Error {},
+}));
+
+vi.mock("next-auth", () => ({ AuthError: MockAuthError }));
+vi.mock("@/lib/db", () => ({ db: mockDb }));
+vi.mock("@/auth", () => ({ signIn: mockSignIn }));
+
+import { signup } from "../auth";
+
+describe("signup", () => {
+  beforeEach(() => {
+    resetTestMocks();
+  });
+
+  function buildFormData(values: Record<string, string>) {
+    const formData = new FormData();
+    Object.entries(values).forEach(([key, value]) => {
+      formData.set(key, value);
+    });
+    return formData;
+  }
+
+  it("requires email and password", async () => {
+    const result = await signup(buildFormData({ name: "Analyst" }));
+
+    expect(result).toEqual({ error: "Email and password are required." });
+  });
+
+  it("requires a minimum password length", async () => {
+    const result = await signup(
+      buildFormData({
+        email: "analyst@example.com",
+        password: "short",
+      }),
+    );
+
+    expect(result).toEqual({ error: "Password must be at least 8 characters." });
+  });
+
+  it("rejects duplicate accounts", async () => {
+    mockDb.user.findUnique.mockResolvedValue({ id: "user-1" });
+
+    const result = await signup(
+      buildFormData({
+        email: "analyst@example.com",
+        password: "password123",
+      }),
+    );
+
+    expect(result).toEqual({
+      error: "An account with this email already exists.",
+    });
+    expect(mockDb.user.create).not.toHaveBeenCalled();
+  });
+
+  it("creates an account and signs the user in", async () => {
+    mockDb.user.findUnique.mockResolvedValue(null);
+
+    const result = await signup(
+      buildFormData({
+        email: " analyst@example.com ",
+        password: "password123",
+        name: " Analyst ",
+      }),
+    );
+
+    expect(result).toBeUndefined();
+    expect(mockDb.user.create).toHaveBeenCalledTimes(1);
+    expect(mockDb.user.create.mock.calls[0][0]).toMatchObject({
+      data: {
+        email: "analyst@example.com",
+        name: "Analyst",
+      },
+    });
+    expect(mockSignIn).toHaveBeenCalledWith("credentials", {
+      email: "analyst@example.com",
+      password: "password123",
+      redirectTo: "/dossiers",
+    });
+  });
+
+  it("returns a friendly message when auto sign-in fails with an auth error", async () => {
+    mockDb.user.findUnique.mockResolvedValue(null);
+    mockSignIn.mockRejectedValue(new MockAuthError("CredentialsSignin"));
+
+    const result = await signup(
+      buildFormData({
+        email: "analyst@example.com",
+        password: "password123",
+      }),
+    );
+
+    expect(result).toEqual({ error: "Account created. Please sign in." });
+  });
+
+  it("rethrows unexpected sign-in failures", async () => {
+    mockDb.user.findUnique.mockResolvedValue(null);
+    mockSignIn.mockRejectedValue(new Error("boom"));
+
+    await expect(
+      signup(
+        buildFormData({
+          email: "analyst@example.com",
+          password: "password123",
+        }),
+      ),
+    ).rejects.toThrow("boom");
+  });
+});

--- a/src/server/actions/__tests__/claims.test.ts
+++ b/src/server/actions/__tests__/claims.test.ts
@@ -1,0 +1,238 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildClaim,
+  buildDossier,
+} from "@/lib/test-utils/factories";
+import {
+  mockAuth,
+  mockAuthenticatedUser,
+  mockDb,
+  mockRevalidatePath,
+  resetTestMocks,
+} from "@/test/mocks";
+
+vi.mock("@/auth", () => ({ auth: mockAuth }));
+vi.mock("@/lib/db", () => ({ db: mockDb }));
+vi.mock("next/cache", () => ({ revalidatePath: mockRevalidatePath }));
+
+import { createClaim, deleteClaim, updateClaim } from "../claims";
+
+describe("claim actions", () => {
+  beforeEach(() => {
+    resetTestMocks();
+  });
+
+  describe("createClaim", () => {
+    it("requires authentication", async () => {
+      const result = await createClaim({
+        dossierId: "dos-1",
+        statement: "Claim",
+        highlightIds: ["hl-1"],
+      });
+
+      expect(result).toEqual({ error: "You must be signed in." });
+    });
+
+    it("validates required fields", async () => {
+      mockAuthenticatedUser();
+
+      await expect(
+        createClaim({
+          dossierId: "",
+          statement: "Claim",
+          highlightIds: ["hl-1"],
+        }),
+      ).resolves.toEqual({ error: "Dossier ID is required." });
+
+      await expect(
+        createClaim({
+          dossierId: "dos-1",
+          statement: "   ",
+          highlightIds: ["hl-1"],
+        }),
+      ).resolves.toEqual({ error: "Statement is required." });
+
+      await expect(
+        createClaim({
+          dossierId: "dos-1",
+          statement: "Claim",
+          status: "bad" as never,
+          highlightIds: ["hl-1"],
+        }),
+      ).resolves.toEqual({
+        error: "Invalid status. Must be one of: open, supported, contested, deprecated.",
+      });
+
+      await expect(
+        createClaim({
+          dossierId: "dos-1",
+          statement: "Claim",
+          confidence: 101,
+          highlightIds: ["hl-1"],
+        }),
+      ).resolves.toEqual({ error: "Confidence must be between 0 and 100." });
+
+      await expect(
+        createClaim({
+          dossierId: "dos-1",
+          statement: "Claim",
+          highlightIds: [],
+        }),
+      ).resolves.toEqual({ error: "At least one highlight is required." });
+    });
+
+    it("rejects dossiers outside the current account", async () => {
+      mockAuthenticatedUser();
+      mockDb.dossier.findFirst.mockResolvedValue(null);
+
+      const result = await createClaim({
+        dossierId: "dos-1",
+        statement: "Claim",
+        highlightIds: ["hl-1"],
+      });
+
+      expect(result).toEqual({ error: "Dossier not found." });
+    });
+
+    it("rejects highlights outside the dossier", async () => {
+      mockAuthenticatedUser();
+      mockDb.dossier.findFirst.mockResolvedValue(buildDossier({ id: "dos-1" }));
+      mockDb.highlight.findMany.mockResolvedValue([{ id: "hl-1" }]);
+
+      const result = await createClaim({
+        dossierId: "dos-1",
+        statement: "Claim",
+        highlightIds: ["hl-1", "hl-2"],
+      });
+
+      expect(result).toEqual({
+        error: "One or more highlights not found in this dossier.",
+      });
+    });
+
+    it("creates a claim and revalidates the dossier views", async () => {
+      mockAuthenticatedUser();
+      mockDb.dossier.findFirst.mockResolvedValue(buildDossier({ id: "dos-1" }));
+      mockDb.highlight.findMany.mockResolvedValue([{ id: "hl-1" }, { id: "hl-2" }]);
+      mockDb.claim.create.mockResolvedValue(buildClaim({ id: "claim-1" }));
+
+      const result = await createClaim({
+        dossierId: "dos-1",
+        statement: "  Claim statement  ",
+        status: "supported",
+        confidence: 80,
+        notes: "  Notes  ",
+        highlightIds: ["hl-1", "hl-2"],
+      });
+
+      expect(result).toEqual({ id: "claim-1" });
+      expect(mockDb.claim.create).toHaveBeenCalledWith({
+        data: {
+          dossier_id: "dos-1",
+          statement: "Claim statement",
+          status: "supported",
+          confidence: 80,
+          notes: "Notes",
+          highlights: {
+            create: [{ highlight_id: "hl-1" }, { highlight_id: "hl-2" }],
+          },
+        },
+      });
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/dossiers/dos-1/claims");
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/dossiers/dos-1/sources");
+    });
+  });
+
+  describe("updateClaim", () => {
+    it("requires authentication", async () => {
+      const result = await updateClaim({ id: "claim-1", statement: "Updated" });
+
+      expect(result).toEqual({ error: "You must be signed in." });
+    });
+
+    it("validates updates", async () => {
+      mockAuthenticatedUser();
+
+      await expect(updateClaim({ id: "", statement: "Updated" })).resolves.toEqual({
+        error: "Claim ID is required.",
+      });
+      await expect(updateClaim({ id: "claim-1", statement: "   " })).resolves.toEqual({
+        error: "Statement cannot be empty.",
+      });
+      await expect(
+        updateClaim({ id: "claim-1", status: "bad" as never }),
+      ).resolves.toEqual({
+        error: "Invalid status. Must be one of: open, supported, contested, deprecated.",
+      });
+      await expect(
+        updateClaim({ id: "claim-1", confidence: -1 }),
+      ).resolves.toEqual({ error: "Confidence must be between 0 and 100." });
+    });
+
+    it("rejects claims outside the current account", async () => {
+      mockAuthenticatedUser();
+      mockDb.claim.findFirst.mockResolvedValue(null);
+
+      const result = await updateClaim({ id: "claim-1", statement: "Updated" });
+
+      expect(result).toEqual({ error: "Claim not found." });
+    });
+
+    it("updates claims and revalidates the dossier views", async () => {
+      mockAuthenticatedUser();
+      mockDb.claim.findFirst.mockResolvedValue({ id: "claim-1", dossier_id: "dos-1" });
+
+      const result = await updateClaim({
+        id: "claim-1",
+        statement: "  Updated statement  ",
+        status: "contested",
+        confidence: 40,
+        notes: "  Notes  ",
+      });
+
+      expect(result).toEqual({ success: true });
+      expect(mockDb.claim.update).toHaveBeenCalledWith({
+        where: { id: "claim-1" },
+        data: {
+          statement: "Updated statement",
+          status: "contested",
+          confidence: 40,
+          notes: "Notes",
+        },
+      });
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/dossiers/dos-1/claims");
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/dossiers/dos-1/sources");
+    });
+  });
+
+  describe("deleteClaim", () => {
+    it("requires authentication", async () => {
+      const result = await deleteClaim("claim-1");
+
+      expect(result).toEqual({ error: "You must be signed in." });
+    });
+
+    it("rejects claims outside the current account", async () => {
+      mockAuthenticatedUser();
+      mockDb.claim.findFirst.mockResolvedValue(null);
+
+      const result = await deleteClaim("claim-1");
+
+      expect(result).toEqual({ error: "Claim not found." });
+    });
+
+    it("deletes claims and revalidates the dossier views", async () => {
+      mockAuthenticatedUser();
+      mockDb.claim.findFirst.mockResolvedValue({ id: "claim-1", dossier_id: "dos-1" });
+
+      const result = await deleteClaim("claim-1");
+
+      expect(result).toEqual({ success: true });
+      expect(mockDb.claim.delete).toHaveBeenCalledWith({
+        where: { id: "claim-1" },
+      });
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/dossiers/dos-1/claims");
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/dossiers/dos-1/sources");
+    });
+  });
+});

--- a/src/server/actions/__tests__/dossiers.test.ts
+++ b/src/server/actions/__tests__/dossiers.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildDossier } from "@/lib/test-utils/factories";
+import {
+  mockAuth,
+  mockAuthenticatedUser,
+  mockDb,
+  mockRedirect,
+  mockRevalidatePath,
+  resetTestMocks,
+} from "@/test/mocks";
+
+vi.mock("@/auth", () => ({ auth: mockAuth }));
+vi.mock("@/lib/db", () => ({ db: mockDb }));
+vi.mock("next/cache", () => ({ revalidatePath: mockRevalidatePath }));
+vi.mock("next/navigation", () => ({ redirect: mockRedirect }));
+
+import {
+  archiveDossier,
+  createDossier,
+  renameDossier,
+} from "../dossiers";
+
+describe("dossier actions", () => {
+  beforeEach(() => {
+    resetTestMocks();
+  });
+
+  function buildFormData(values: Record<string, string>) {
+    const formData = new FormData();
+    Object.entries(values).forEach(([key, value]) => {
+      formData.set(key, value);
+    });
+    return formData;
+  }
+
+  describe("createDossier", () => {
+    it("requires authentication", async () => {
+      const result = await createDossier(
+        null,
+        buildFormData({ title: "Briefing" }),
+      );
+
+      expect(result).toBe("You must be signed in.");
+    });
+
+    it("requires a title", async () => {
+      mockAuthenticatedUser();
+
+      const result = await createDossier(null, buildFormData({ title: "   " }));
+
+      expect(result).toBe("Title is required.");
+    });
+
+    it("creates a dossier with a unique slug and redirects to it", async () => {
+      mockAuthenticatedUser("user-1");
+      mockDb.dossier.findFirst
+        .mockResolvedValueOnce(buildDossier({ id: "existing", slug: "briefing" }))
+        .mockResolvedValueOnce(null);
+      mockDb.dossier.create.mockResolvedValue(buildDossier({ id: "dos-123" }));
+
+      await expect(
+        createDossier(
+          null,
+          buildFormData({
+            title: "Briefing",
+            summary: "  Summary  ",
+            research_goal: "  Goal  ",
+          }),
+        ),
+      ).rejects.toThrow("redirect:/dossiers/dos-123");
+
+      expect(mockDb.dossier.create).toHaveBeenCalledWith({
+        data: {
+          owner_id: "user-1",
+          title: "Briefing",
+          slug: "briefing-1",
+          summary: "Summary",
+          research_goal: "Goal",
+        },
+      });
+    });
+
+    it("returns an error when creation fails", async () => {
+      mockAuthenticatedUser();
+      mockDb.dossier.findFirst.mockResolvedValue(null);
+      mockDb.dossier.create.mockRejectedValue(new Error("boom"));
+
+      const result = await createDossier(
+        null,
+        buildFormData({ title: "Briefing" }),
+      );
+
+      expect(result).toBe("Failed to create dossier. Please try again.");
+    });
+  });
+
+  describe("renameDossier", () => {
+    it("rejects unauthenticated users", async () => {
+      await expect(renameDossier("dos-1", "Renamed")).rejects.toThrow(
+        "Unauthorized",
+      );
+    });
+
+    it("rejects empty titles", async () => {
+      mockAuthenticatedUser();
+
+      await expect(renameDossier("dos-1", "   ")).rejects.toThrow(
+        "Title is required",
+      );
+    });
+
+    it("rejects dossiers outside the current account", async () => {
+      mockAuthenticatedUser();
+      mockDb.dossier.findFirst.mockResolvedValue(null);
+
+      await expect(renameDossier("dos-1", "Renamed")).rejects.toThrow(
+        "Not found",
+      );
+    });
+
+    it("reuses the existing slug when the title is unchanged", async () => {
+      mockAuthenticatedUser("user-1");
+      mockDb.dossier.findFirst.mockResolvedValue(
+        buildDossier({ id: "dos-1", title: "Current Title", slug: "current-title" }),
+      );
+
+      await renameDossier("dos-1", " Current Title ");
+
+      expect(mockDb.dossier.update).toHaveBeenCalledWith({
+        where: { id: "dos-1" },
+        data: { title: "Current Title", slug: "current-title" },
+      });
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/dossiers");
+    });
+
+    it("generates a new unique slug when the title changes", async () => {
+      mockAuthenticatedUser("user-1");
+      mockDb.dossier.findFirst
+        .mockResolvedValueOnce(
+          buildDossier({ id: "dos-1", title: "Current", slug: "current" }),
+        )
+        .mockResolvedValueOnce(buildDossier({ id: "dos-2", slug: "new-title" }))
+        .mockResolvedValueOnce(null);
+
+      await renameDossier("dos-1", "New Title");
+
+      expect(mockDb.dossier.update).toHaveBeenCalledWith({
+        where: { id: "dos-1" },
+        data: { title: "New Title", slug: "new-title-1" },
+      });
+    });
+  });
+
+  describe("archiveDossier", () => {
+    it("rejects unauthenticated users", async () => {
+      await expect(archiveDossier("dos-1")).rejects.toThrow("Unauthorized");
+    });
+
+    it("rejects dossiers outside the current account", async () => {
+      mockAuthenticatedUser();
+      mockDb.dossier.findFirst.mockResolvedValue(null);
+
+      await expect(archiveDossier("dos-1")).rejects.toThrow("Not found");
+    });
+
+    it("archives the dossier and revalidates the listing", async () => {
+      mockAuthenticatedUser("user-1");
+      mockDb.dossier.findFirst.mockResolvedValue(buildDossier({ id: "dos-1" }));
+
+      await archiveDossier("dos-1");
+
+      expect(mockDb.dossier.update).toHaveBeenCalledWith({
+        where: { id: "dos-1" },
+        data: { status: "archived" },
+      });
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/dossiers");
+    });
+  });
+});

--- a/src/server/actions/__tests__/entities.test.ts
+++ b/src/server/actions/__tests__/entities.test.ts
@@ -1,0 +1,328 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildClaim,
+  buildDossier,
+  buildEntity,
+  buildSource,
+} from "@/lib/test-utils/factories";
+import {
+  mockAuth,
+  mockAuthenticatedUser,
+  mockDb,
+  mockRevalidatePath,
+  resetTestMocks,
+} from "@/test/mocks";
+
+vi.mock("@/auth", () => ({ auth: mockAuth }));
+vi.mock("@/lib/db", () => ({ db: mockDb }));
+vi.mock("next/cache", () => ({ revalidatePath: mockRevalidatePath }));
+
+import {
+  createEntity,
+  deleteEntity,
+  linkEntity,
+  updateEntity,
+} from "../entities";
+
+describe("entity actions", () => {
+  beforeEach(() => {
+    resetTestMocks();
+  });
+
+  describe("createEntity", () => {
+    it("requires authentication", async () => {
+      const result = await createEntity({
+        dossierId: "dos-1",
+        name: "Entity",
+        type: "person",
+      });
+
+      expect(result).toEqual({ error: "You must be signed in." });
+    });
+
+    it("validates required fields", async () => {
+      mockAuthenticatedUser();
+
+      await expect(
+        createEntity({ dossierId: "", name: "Entity", type: "person" }),
+      ).resolves.toEqual({ error: "Dossier ID is required." });
+      await expect(
+        createEntity({ dossierId: "dos-1", name: "   ", type: "person" }),
+      ).resolves.toEqual({ error: "Entity name is required." });
+      await expect(
+        createEntity({
+          dossierId: "dos-1",
+          name: "Entity",
+          type: "invalid" as never,
+        }),
+      ).resolves.toEqual({
+        error: "Invalid entity type. Must be one of: person, company, product, location, institution, topic.",
+      });
+      await expect(
+        createEntity({
+          dossierId: "dos-1",
+          name: "Entity",
+          type: "person",
+          importance: 101,
+        }),
+      ).resolves.toEqual({ error: "Importance must be between 0 and 100." });
+    });
+
+    it("rejects dossiers outside the current account", async () => {
+      mockAuthenticatedUser();
+      mockDb.dossier.findFirst.mockResolvedValue(null);
+
+      const result = await createEntity({
+        dossierId: "dos-1",
+        name: "Entity",
+        type: "person",
+      });
+
+      expect(result).toEqual({ error: "Dossier not found." });
+    });
+
+    it("creates an entity and revalidates the dossier layout", async () => {
+      mockAuthenticatedUser();
+      mockDb.dossier.findFirst.mockResolvedValue(buildDossier({ id: "dos-1" }));
+      mockDb.entity.create.mockResolvedValue({ id: "entity-1" });
+
+      const result = await createEntity({
+        dossierId: "dos-1",
+        name: "  Entity  ",
+        type: "company",
+        description: "  Description  ",
+        aliases: ["", "Alias", "Other"],
+        importance: 80,
+      });
+
+      expect(result).toEqual({ id: "entity-1" });
+      expect(mockDb.entity.create).toHaveBeenCalledWith({
+        data: {
+          dossier_id: "dos-1",
+          name: "Entity",
+          type: "company",
+          description: "Description",
+          aliases: ["Alias", "Other"],
+          importance: 80,
+        },
+        select: { id: true },
+      });
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/dossiers/dos-1", "layout");
+    });
+  });
+
+  describe("updateEntity", () => {
+    it("validates updates", async () => {
+      mockAuthenticatedUser();
+
+      await expect(updateEntity({ id: "", name: "Entity" })).resolves.toEqual({
+        error: "Entity ID is required.",
+      });
+      await expect(updateEntity({ id: "entity-1", name: "   " })).resolves.toEqual({
+        error: "Entity name cannot be empty.",
+      });
+      await expect(
+        updateEntity({ id: "entity-1", type: "bad" as never }),
+      ).resolves.toEqual({
+        error: "Invalid entity type. Must be one of: person, company, product, location, institution, topic.",
+      });
+      await expect(
+        updateEntity({ id: "entity-1", importance: -1 }),
+      ).resolves.toEqual({ error: "Importance must be between 0 and 100." });
+    });
+
+    it("rejects entities outside the current account", async () => {
+      mockAuthenticatedUser();
+      mockDb.entity.findFirst.mockResolvedValue(null);
+
+      const result = await updateEntity({ id: "entity-1", name: "Entity" });
+
+      expect(result).toEqual({ error: "Entity not found." });
+    });
+
+    it("updates an entity and revalidates the dossier layout", async () => {
+      mockAuthenticatedUser();
+      mockDb.entity.findFirst.mockResolvedValue({
+        id: "entity-1",
+        dossier_id: "dos-1",
+      });
+
+      const result = await updateEntity({
+        id: "entity-1",
+        name: "  Entity  ",
+        type: "topic",
+        description: "  Description  ",
+        aliases: ["", "Alias"],
+        importance: 50,
+      });
+
+      expect(result).toEqual({ success: true });
+      expect(mockDb.entity.update).toHaveBeenCalledWith({
+        where: { id: "entity-1" },
+        data: {
+          name: "Entity",
+          type: "topic",
+          description: "Description",
+          aliases: ["Alias"],
+          importance: 50,
+        },
+      });
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/dossiers/dos-1", "layout");
+    });
+  });
+
+  describe("deleteEntity", () => {
+    it("rejects entities outside the current account", async () => {
+      mockAuthenticatedUser();
+      mockDb.entity.findFirst.mockResolvedValue(null);
+
+      const result = await deleteEntity("entity-1");
+
+      expect(result).toEqual({ error: "Entity not found." });
+    });
+
+    it("deletes an entity and revalidates the dossier layout", async () => {
+      mockAuthenticatedUser();
+      mockDb.entity.findFirst.mockResolvedValue({
+        id: "entity-1",
+        dossier_id: "dos-1",
+      });
+
+      const result = await deleteEntity("entity-1");
+
+      expect(result).toEqual({ success: true });
+      expect(mockDb.entity.delete).toHaveBeenCalledWith({
+        where: { id: "entity-1" },
+      });
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/dossiers/dos-1", "layout");
+    });
+  });
+
+  describe("linkEntity", () => {
+    it("requires exactly one target", async () => {
+      mockAuthenticatedUser();
+
+      const result = await linkEntity({
+        entityId: "entity-1",
+        sourceId: "source-1",
+        claimId: "claim-1",
+      });
+
+      expect(result).toEqual({ error: "Linking requires exactly one target." });
+    });
+
+    it("rejects entities outside the current account", async () => {
+      mockAuthenticatedUser();
+      mockDb.entity.findFirst.mockResolvedValue(null);
+
+      const result = await linkEntity({ entityId: "entity-1", claimId: "claim-1" });
+
+      expect(result).toEqual({ error: "Entity not found." });
+    });
+
+    it("links a claim and revalidates the dossier layout", async () => {
+      mockAuthenticatedUser();
+      mockDb.entity.findFirst.mockResolvedValue(
+        buildEntity({ id: "entity-1", dossier_id: "dos-1" }),
+      );
+      mockDb.claim.findFirst.mockResolvedValue(
+        buildClaim({ id: "claim-1", dossier_id: "dos-1" }),
+      );
+
+      const result = await linkEntity({ entityId: "entity-1", claimId: "claim-1" });
+
+      expect(result).toEqual({ success: true });
+      expect(mockDb.claimEntity.upsert).toHaveBeenCalledWith({
+        where: {
+          claim_id_entity_id: {
+            claim_id: "claim-1",
+            entity_id: "entity-1",
+          },
+        },
+        update: {},
+        create: {
+          claim_id: "claim-1",
+          entity_id: "entity-1",
+        },
+      });
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/dossiers/dos-1", "layout");
+    });
+
+    it("creates a mention from a source summary when linking a source", async () => {
+      mockAuthenticatedUser();
+      mockDb.entity.findFirst.mockResolvedValue(
+        buildEntity({ id: "entity-1", dossier_id: "dos-1" }),
+      );
+      mockDb.source.findFirst.mockResolvedValue(
+        buildSource({
+          id: "source-1",
+          dossier_id: "dos-1",
+          summary: "  Summary text  ",
+          raw_text: "Raw text fallback",
+          title: "Source title",
+        }),
+      );
+      mockDb.mention.findFirst.mockResolvedValue(null);
+
+      const result = await linkEntity({ entityId: "entity-1", sourceId: "source-1" });
+
+      expect(result).toEqual({ success: true });
+      expect(mockDb.mention.create).toHaveBeenCalledWith({
+        data: {
+          entity_id: "entity-1",
+          source_id: "source-1",
+          context_snippet: "Summary text",
+        },
+      });
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/dossiers/dos-1", "layout");
+    });
+
+    it("skips mention creation when the source link already exists", async () => {
+      mockAuthenticatedUser();
+      mockDb.entity.findFirst.mockResolvedValue(
+        buildEntity({ id: "entity-1", dossier_id: "dos-1" }),
+      );
+      mockDb.source.findFirst.mockResolvedValue(
+        buildSource({ id: "source-1", dossier_id: "dos-1", title: "Source title" }),
+      );
+      mockDb.mention.findFirst.mockResolvedValue({ id: "mention-1" });
+
+      const result = await linkEntity({
+        entityId: "entity-1",
+        sourceId: "source-1",
+        contextSnippet: "  Manual context  ",
+      });
+
+      expect(result).toEqual({ success: true });
+      expect(mockDb.mention.create).not.toHaveBeenCalled();
+    });
+
+    it("creates a mention from highlight text when linking a highlight", async () => {
+      mockAuthenticatedUser();
+      mockDb.entity.findFirst.mockResolvedValue(
+        buildEntity({ id: "entity-1", dossier_id: "dos-1" }),
+      );
+      mockDb.highlight.findFirst.mockResolvedValue({
+        id: "hl-1",
+        quote_text: "Quoted evidence",
+        source: { dossier_id: "dos-1" },
+      });
+      mockDb.mention.findFirst.mockResolvedValue(null);
+
+      const result = await linkEntity({
+        entityId: "entity-1",
+        highlightId: "hl-1",
+      });
+
+      expect(result).toEqual({ success: true });
+      expect(mockDb.mention.create).toHaveBeenCalledWith({
+        data: {
+          entity_id: "entity-1",
+          highlight_id: "hl-1",
+          context_snippet: "Quoted evidence",
+        },
+      });
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/dossiers/dos-1", "layout");
+    });
+  });
+});

--- a/src/server/actions/__tests__/highlights.test.ts
+++ b/src/server/actions/__tests__/highlights.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildHighlight,
+  buildSource,
+} from "@/lib/test-utils/factories";
+import {
+  mockAuth,
+  mockAuthenticatedUser,
+  mockDb,
+  mockRevalidatePath,
+  resetTestMocks,
+} from "@/test/mocks";
+
+vi.mock("@/auth", () => ({ auth: mockAuth }));
+vi.mock("@/lib/db", () => ({ db: mockDb }));
+vi.mock("next/cache", () => ({ revalidatePath: mockRevalidatePath }));
+
+import { createHighlight, deleteHighlight } from "../highlights";
+
+describe("highlight actions", () => {
+  beforeEach(() => {
+    resetTestMocks();
+  });
+
+  describe("createHighlight", () => {
+    it("requires authentication", async () => {
+      const result = await createHighlight({
+        sourceId: "source-1",
+        quoteText: "Evidence",
+        startOffset: 0,
+        endOffset: 8,
+      });
+
+      expect(result).toEqual({ error: "You must be signed in." });
+    });
+
+    it("validates required fields and offsets", async () => {
+      mockAuthenticatedUser();
+
+      await expect(
+        createHighlight({
+          sourceId: "",
+          quoteText: "Evidence",
+          startOffset: 0,
+          endOffset: 8,
+        }),
+      ).resolves.toEqual({ error: "Source ID is required." });
+
+      await expect(
+        createHighlight({
+          sourceId: "source-1",
+          quoteText: "   ",
+          startOffset: 0,
+          endOffset: 8,
+        }),
+      ).resolves.toEqual({ error: "Quote text is required." });
+
+      await expect(
+        createHighlight({
+          sourceId: "source-1",
+          quoteText: "Evidence",
+          startOffset: -1,
+          endOffset: 8,
+        }),
+      ).resolves.toEqual({ error: "Invalid start offset." });
+
+      await expect(
+        createHighlight({
+          sourceId: "source-1",
+          quoteText: "Evidence",
+          startOffset: 5,
+          endOffset: 5,
+        }),
+      ).resolves.toEqual({ error: "Invalid offset range." });
+    });
+
+    it("rejects invalid labels", async () => {
+      mockAuthenticatedUser();
+
+      const result = await createHighlight({
+        sourceId: "source-1",
+        quoteText: "Evidence",
+        startOffset: 0,
+        endOffset: 8,
+        label: "bad-label" as never,
+      });
+
+      expect(result).toEqual({
+        error: "Invalid label. Must be one of: evidence, question, counterpoint, stat, quote.",
+      });
+    });
+
+    it("rejects sources outside the current account", async () => {
+      mockAuthenticatedUser();
+      mockDb.source.findFirst.mockResolvedValue(null);
+
+      const result = await createHighlight({
+        sourceId: "source-1",
+        quoteText: "Evidence",
+        startOffset: 0,
+        endOffset: 8,
+      });
+
+      expect(result).toEqual({ error: "Source not found." });
+    });
+
+    it("creates a highlight and revalidates the reader page", async () => {
+      mockAuthenticatedUser();
+      mockDb.source.findFirst.mockResolvedValue(
+        buildSource({ id: "source-1", dossier_id: "dos-1" }),
+      );
+      mockDb.highlight.create.mockResolvedValue(buildHighlight({ id: "hl-1" }));
+
+      const result = await createHighlight({
+        sourceId: "source-1",
+        quoteText: "Evidence",
+        startOffset: 2,
+        endOffset: 10,
+        annotation: "  Annotated  ",
+      });
+
+      expect(result).toEqual({ id: "hl-1" });
+      expect(mockDb.highlight.create).toHaveBeenCalledWith({
+        data: {
+          source_id: "source-1",
+          quote_text: "Evidence",
+          start_offset: 2,
+          end_offset: 10,
+          label: "evidence",
+          annotation: "Annotated",
+        },
+      });
+      expect(mockRevalidatePath).toHaveBeenCalledWith(
+        "/dossiers/dos-1/sources/source-1",
+      );
+    });
+  });
+
+  describe("deleteHighlight", () => {
+    it("requires authentication", async () => {
+      const result = await deleteHighlight("hl-1");
+
+      expect(result).toEqual({ error: "You must be signed in." });
+    });
+
+    it("rejects highlights outside the current account", async () => {
+      mockAuthenticatedUser();
+      mockDb.highlight.findFirst.mockResolvedValue(null);
+
+      const result = await deleteHighlight("hl-1");
+
+      expect(result).toEqual({ error: "Highlight not found." });
+    });
+
+    it("deletes the highlight and revalidates the reader page", async () => {
+      mockAuthenticatedUser();
+      mockDb.highlight.findFirst.mockResolvedValue({
+        id: "hl-1",
+        source: { id: "source-1", dossier_id: "dos-1" },
+      });
+
+      const result = await deleteHighlight("hl-1");
+
+      expect(result).toEqual({ success: true });
+      expect(mockDb.highlight.delete).toHaveBeenCalledWith({
+        where: { id: "hl-1" },
+      });
+      expect(mockRevalidatePath).toHaveBeenCalledWith(
+        "/dossiers/dos-1/sources/source-1",
+      );
+    });
+  });
+});

--- a/src/server/actions/__tests__/sources.test.ts
+++ b/src/server/actions/__tests__/sources.test.ts
@@ -1,0 +1,295 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildSource,
+} from "@/lib/test-utils/factories";
+import {
+  mockAuth,
+  mockAuthenticatedUser,
+  mockDb,
+  mockRevalidatePath,
+  resetTestMocks,
+} from "@/test/mocks";
+
+vi.mock("@/auth", () => ({ auth: mockAuth }));
+vi.mock("@/lib/db", () => ({ db: mockDb }));
+vi.mock("next/cache", () => ({ revalidatePath: mockRevalidatePath }));
+
+import {
+  createSource,
+  deleteSource,
+  updateSource,
+  updateSourceStatus,
+} from "../sources";
+
+describe("source actions", () => {
+  beforeEach(() => {
+    resetTestMocks();
+  });
+
+  describe("createSource", () => {
+    it("requires authentication", async () => {
+      const result = await createSource({
+        dossierId: "dos-1",
+        type: "web_link",
+        title: "Source",
+        url: "https://example.com",
+      });
+
+      expect(result).toEqual({ error: "You must be signed in." });
+    });
+
+    it("validates input and type-specific requirements", async () => {
+      mockAuthenticatedUser();
+
+      await expect(
+        createSource({
+          dossierId: "",
+          type: "web_link",
+          title: "Source",
+          url: "https://example.com",
+        }),
+      ).resolves.toEqual({ error: "Dossier ID is required." });
+
+      await expect(
+        createSource({
+          dossierId: "dos-1",
+          type: "web_link",
+          title: "   ",
+          url: "https://example.com",
+        }),
+      ).resolves.toEqual({ error: "Title is required." });
+
+      await expect(
+        createSource({
+          dossierId: "dos-1",
+          type: "bad" as never,
+          title: "Source",
+        }),
+      ).resolves.toEqual({
+        error: "Invalid source type. Must be one of: web_link, pdf, pasted_text, manual_note, internal_memo.",
+      });
+
+      await expect(
+        createSource({
+          dossierId: "dos-1",
+          type: "web_link",
+          title: "Source",
+        }),
+      ).resolves.toEqual({ error: "URL is required for web link sources." });
+
+      await expect(
+        createSource({
+          dossierId: "dos-1",
+          type: "manual_note",
+          title: "Source",
+        }),
+      ).resolves.toEqual({ error: "Note content is required for manual note sources." });
+
+      await expect(
+        createSource({
+          dossierId: "dos-1",
+          type: "web_link",
+          title: "Source",
+          url: "https://example.com",
+          credibilityRating: 101,
+        }),
+      ).resolves.toEqual({
+        error: "Credibility rating must be an integer between 0 and 100.",
+      });
+
+      await expect(
+        createSource({
+          dossierId: "dos-1",
+          type: "web_link",
+          title: "Source",
+          url: "https://example.com",
+          publishedAt: "not-a-date",
+        }),
+      ).resolves.toEqual({ error: "Published date is invalid." });
+    });
+
+    it("rejects dossiers outside the current account", async () => {
+      mockAuthenticatedUser();
+      mockDb.dossier.findFirst.mockResolvedValue(null);
+
+      const result = await createSource({
+        dossierId: "dos-1",
+        type: "web_link",
+        title: "Source",
+        url: "https://example.com",
+      });
+
+      expect(result).toEqual({ error: "Dossier not found." });
+    });
+
+    it("creates sources and revalidates the listing", async () => {
+      mockAuthenticatedUser();
+      mockDb.dossier.findFirst.mockResolvedValue({ id: "dos-1" });
+      mockDb.source.create.mockResolvedValue(buildSource({ id: "source-1" }));
+
+      const result = await createSource({
+        dossierId: "dos-1",
+        type: "web_link",
+        title: "  Source  ",
+        url: " https://example.com ",
+        author: "  Author  ",
+        publisher: "  Publisher  ",
+        publishedAt: "2024-03-01T00:00:00.000Z",
+        rawText: "Raw text",
+        summary: "  Summary  ",
+        credibilityRating: 70,
+        sourceStatus: "reviewing",
+      });
+
+      expect(result).toEqual({ id: "source-1" });
+      expect(mockDb.source.create).toHaveBeenCalledWith({
+        data: {
+          dossier_id: "dos-1",
+          type: "web_link",
+          title: "Source",
+          url: "https://example.com",
+          author: "Author",
+          publisher: "Publisher",
+          published_at: new Date("2024-03-01T00:00:00.000Z"),
+          raw_text: "Raw text",
+          summary: "Summary",
+          credibility_rating: 70,
+          source_status: "reviewing",
+        },
+      });
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/dossiers/dos-1/sources");
+    });
+  });
+
+  describe("updateSource", () => {
+    it("rejects sources outside the current account", async () => {
+      mockAuthenticatedUser();
+      mockDb.source.findFirst.mockResolvedValue(null);
+
+      const result = await updateSource("source-1", { title: "Updated" });
+
+      expect(result).toEqual({ error: "Source not found." });
+    });
+
+    it("validates update input", async () => {
+      mockAuthenticatedUser();
+      mockDb.source.findFirst.mockResolvedValue(
+        buildSource({ id: "source-1", type: "web_link", url: "https://example.com" }),
+      );
+
+      await expect(
+        updateSource("source-1", { type: "bad" as never }),
+      ).resolves.toEqual({
+        error: "Invalid source type. Must be one of: web_link, pdf, pasted_text, manual_note, internal_memo.",
+      });
+      await expect(
+        updateSource("source-1", { sourceStatus: "bad" as never }),
+      ).resolves.toEqual({
+        error: "Invalid source status. Must be one of: unreviewed, reviewing, reviewed, discarded.",
+      });
+      await expect(updateSource("source-1", { title: "   " })).resolves.toEqual({
+        error: "Title is required.",
+      });
+      await expect(
+        updateSource("source-1", { credibilityRating: 1.5 }),
+      ).resolves.toEqual({
+        error: "Credibility rating must be an integer between 0 and 100.",
+      });
+      await expect(
+        updateSource("source-1", { publishedAt: "not-a-date" }),
+      ).resolves.toEqual({ error: "Published date is invalid." });
+    });
+
+    it("enforces type-specific requirements against the merged source state", async () => {
+      mockAuthenticatedUser();
+      mockDb.source.findFirst.mockResolvedValue(
+        buildSource({ id: "source-1", type: "web_link", url: "https://example.com" }),
+      );
+
+      const result = await updateSource("source-1", { url: "   " });
+
+      expect(result).toEqual({ error: "URL is required for web link sources." });
+    });
+
+    it("updates sources and revalidates the listing", async () => {
+      mockAuthenticatedUser();
+      mockDb.source.findFirst.mockResolvedValue(
+        buildSource({ id: "source-1", dossier_id: "dos-1", type: "web_link" }),
+      );
+
+      const result = await updateSource("source-1", {
+        title: "  Updated  ",
+        url: " https://example.com ",
+        author: "  Author  ",
+        publisher: "  Publisher  ",
+        publishedAt: "2024-03-01T00:00:00.000Z",
+        rawText: "Updated text",
+        summary: "  Summary  ",
+        credibilityRating: 75,
+        sourceStatus: "reviewed",
+      });
+
+      expect(result).toEqual({ success: true });
+      expect(mockDb.source.update).toHaveBeenCalledWith({
+        where: { id: "source-1" },
+        data: {
+          title: "Updated",
+          url: "https://example.com",
+          author: "Author",
+          publisher: "Publisher",
+          published_at: new Date("2024-03-01T00:00:00.000Z"),
+          raw_text: "Updated text",
+          summary: "Summary",
+          credibility_rating: 75,
+          source_status: "reviewed",
+        },
+      });
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/dossiers/dos-1/sources");
+    });
+  });
+
+  describe("updateSourceStatus", () => {
+    it("validates the requested status", async () => {
+      mockAuthenticatedUser();
+
+      const result = await updateSourceStatus("source-1", "bad" as never);
+
+      expect(result).toEqual({
+        error: "Invalid source status. Must be one of: unreviewed, reviewing, reviewed, discarded.",
+      });
+    });
+
+    it("updates the status and revalidates the listing", async () => {
+      mockAuthenticatedUser();
+      mockDb.source.findFirst.mockResolvedValue(
+        buildSource({ id: "source-1", dossier_id: "dos-1" }),
+      );
+
+      const result = await updateSourceStatus("source-1", "discarded");
+
+      expect(result).toEqual({ success: true });
+      expect(mockDb.source.update).toHaveBeenCalledWith({
+        where: { id: "source-1" },
+        data: { source_status: "discarded" },
+      });
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/dossiers/dos-1/sources");
+    });
+  });
+
+  describe("deleteSource", () => {
+    it("deletes the source and revalidates the listing", async () => {
+      mockAuthenticatedUser();
+      mockDb.source.findFirst.mockResolvedValue(
+        buildSource({ id: "source-1", dossier_id: "dos-1" }),
+      );
+
+      const result = await deleteSource("source-1");
+
+      expect(result).toEqual({ success: true });
+      expect(mockDb.source.delete).toHaveBeenCalledWith({
+        where: { id: "source-1" },
+      });
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/dossiers/dos-1/sources");
+    });
+  });
+});

--- a/src/server/queries/__tests__/queries.test.ts
+++ b/src/server/queries/__tests__/queries.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildDossier, buildSource } from "@/lib/test-utils/factories";
+import { mockDb, resetTestMocks } from "@/test/mocks";
+
+vi.mock("@/lib/db", () => ({ db: mockDb }));
+
+import {
+  getDossier,
+  getDossiers,
+} from "../dossiers";
+import { getEntities } from "../entities";
+import { getClaims, getClaimsForSource } from "../claims";
+import {
+  getSource,
+  getSourceForReader,
+  getSources,
+} from "../sources";
+
+describe("server queries", () => {
+  beforeEach(() => {
+    resetTestMocks();
+  });
+
+  it("gets active dossiers ordered by update time", async () => {
+    const expected = [{ id: "dos-1" }];
+    mockDb.dossier.findMany.mockResolvedValue(expected);
+
+    await expect(getDossiers("user-1")).resolves.toBe(expected);
+    expect(mockDb.dossier.findMany).toHaveBeenCalledWith({
+      where: {
+        owner_id: "user-1",
+        status: "active",
+      },
+      orderBy: { updated_at: "desc" },
+      select: expect.any(Object),
+    });
+  });
+
+  it("gets a single dossier for the current owner", async () => {
+    const dossier = buildDossier({ id: "dos-1", owner_id: "user-1" });
+    mockDb.dossier.findFirst.mockResolvedValue(dossier);
+
+    await expect(getDossier("dos-1", "user-1")).resolves.toBe(dossier);
+    expect(mockDb.dossier.findFirst).toHaveBeenCalledWith({
+      where: { id: "dos-1", owner_id: "user-1" },
+    });
+  });
+
+  it("gets dossier sources with tag and highlight counts", async () => {
+    const sources = [{ id: "source-1" }];
+    mockDb.source.findMany.mockResolvedValue(sources);
+
+    await expect(getSources("dos-1", "user-1")).resolves.toBe(sources);
+    expect(mockDb.source.findMany).toHaveBeenCalledWith({
+      where: {
+        dossier_id: "dos-1",
+        dossier: { owner_id: "user-1" },
+      },
+      orderBy: { created_at: "desc" },
+      select: expect.any(Object),
+    });
+  });
+
+  it("gets a single source scoped to the current owner", async () => {
+    const source = buildSource({ id: "source-1", dossier_id: "dos-1" });
+    mockDb.source.findFirst.mockResolvedValue(source);
+
+    await expect(getSource("source-1", "user-1")).resolves.toBe(source);
+    expect(mockDb.source.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: "source-1",
+        dossier: { owner_id: "user-1" },
+      },
+    });
+  });
+
+  it("gets a reader-ready source payload with related evidence", async () => {
+    const readerData = { id: "source-1", highlights: [] };
+    mockDb.source.findFirst.mockResolvedValue(readerData);
+
+    await expect(
+      getSourceForReader("source-1", "dos-1", "user-1"),
+    ).resolves.toBe(readerData);
+    expect(mockDb.source.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: "source-1",
+        dossier_id: "dos-1",
+        dossier: { owner_id: "user-1" },
+      },
+      include: expect.any(Object),
+    });
+  });
+
+  it("gets dossier entities ordered by recency and name", async () => {
+    const entities = [{ id: "entity-1" }];
+    mockDb.entity.findMany.mockResolvedValue(entities);
+
+    await expect(getEntities("dos-1", "user-1")).resolves.toBe(entities);
+    expect(mockDb.entity.findMany).toHaveBeenCalledWith({
+      where: {
+        dossier_id: "dos-1",
+        dossier: { owner_id: "user-1" },
+      },
+      orderBy: [{ updated_at: "desc" }, { name: "asc" }],
+      select: expect.any(Object),
+    });
+  });
+
+  it("gets dossier claims with linked highlights and entities", async () => {
+    const claims = [{ id: "claim-1" }];
+    mockDb.claim.findMany.mockResolvedValue(claims);
+
+    await expect(getClaims("dos-1", "user-1")).resolves.toBe(claims);
+    expect(mockDb.claim.findMany).toHaveBeenCalledWith({
+      where: {
+        dossier_id: "dos-1",
+        dossier: { owner_id: "user-1" },
+      },
+      orderBy: { created_at: "desc" },
+      select: expect.any(Object),
+    });
+  });
+
+  it("gets claims linked to a source", async () => {
+    const claims = [{ id: "claim-1" }];
+    mockDb.claim.findMany.mockResolvedValue(claims);
+
+    await expect(
+      getClaimsForSource("source-1", "dos-1", "user-1"),
+    ).resolves.toBe(claims);
+    expect(mockDb.claim.findMany).toHaveBeenCalledWith({
+      where: {
+        dossier_id: "dos-1",
+        dossier: { owner_id: "user-1" },
+        highlights: {
+          some: {
+            highlight: { source_id: "source-1" },
+          },
+        },
+      },
+      orderBy: { created_at: "desc" },
+      select: expect.any(Object),
+    });
+  });
+});

--- a/src/test/mocks.ts
+++ b/src/test/mocks.ts
@@ -1,0 +1,76 @@
+import { vi } from "vitest";
+
+type MockFn = ReturnType<typeof vi.fn>;
+type MockDelegate = Record<string, MockFn>;
+
+function createDelegate<const T extends readonly string[]>(
+  methods: T,
+): Record<T[number], MockFn> {
+  return Object.fromEntries(methods.map((method) => [method, vi.fn()])) as Record<
+    T[number],
+    MockFn
+  >;
+}
+
+export const mockAuth = vi.fn();
+export const mockSignIn = vi.fn();
+export const mockRevalidatePath = vi.fn();
+export const mockRedirect = vi.fn();
+export const mockRouterRefresh = vi.fn();
+export const mockUseRouter = vi.fn(() => ({ refresh: mockRouterRefresh }));
+
+export const mockDb = {
+  user: createDelegate(["findUnique", "create"] as const),
+  dossier: createDelegate(
+    ["findFirst", "findMany", "create", "update", "delete"] as const,
+  ),
+  source: createDelegate(
+    ["findFirst", "findMany", "create", "update", "delete"] as const,
+  ),
+  highlight: createDelegate(
+    ["findFirst", "findMany", "create", "delete"] as const,
+  ),
+  claim: createDelegate(
+    ["findFirst", "findMany", "create", "update", "delete"] as const,
+  ),
+  entity: createDelegate(
+    ["findFirst", "findMany", "create", "update", "delete"] as const,
+  ),
+  mention: createDelegate(["findFirst", "create"] as const),
+  claimEntity: createDelegate(["upsert"] as const),
+} as const;
+
+function resetDelegate(delegate: MockDelegate) {
+  Object.values(delegate).forEach((fn) => fn.mockReset());
+}
+
+export function resetTestMocks() {
+  mockAuth.mockReset();
+  mockAuth.mockResolvedValue(null);
+
+  mockSignIn.mockReset();
+  mockSignIn.mockResolvedValue(undefined);
+
+  mockRevalidatePath.mockReset();
+  mockRedirect.mockReset();
+  mockRedirect.mockImplementation((path: string) => {
+    throw new Error(`redirect:${path}`);
+  });
+
+  mockRouterRefresh.mockReset();
+  mockUseRouter.mockReset();
+  mockUseRouter.mockImplementation(() => ({ refresh: mockRouterRefresh }));
+
+  resetDelegate(mockDb.user);
+  resetDelegate(mockDb.dossier);
+  resetDelegate(mockDb.source);
+  resetDelegate(mockDb.highlight);
+  resetDelegate(mockDb.claim);
+  resetDelegate(mockDb.entity);
+  resetDelegate(mockDb.mention);
+  resetDelegate(mockDb.claimEntity);
+}
+
+export function mockAuthenticatedUser(userId = "user-1") {
+  mockAuth.mockResolvedValue({ user: { id: userId } });
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,27 @@
 import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+afterEach(() => {
+  cleanup();
+});
+
+if (typeof HTMLDialogElement !== "undefined") {
+  const dialogProto = HTMLDialogElement.prototype as HTMLDialogElement & {
+    showModal?: () => void;
+    close?: () => void;
+  };
+
+  if (!dialogProto.showModal) {
+    dialogProto.showModal = function showModal() {
+      this.open = true;
+    };
+  }
+
+  if (!dialogProto.close) {
+    dialogProto.close = function close() {
+      this.open = false;
+      this.dispatchEvent(new Event("close"));
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add a repository-wide Vitest test harness for auth, Prisma, Next cache/navigation, and browser dialog behavior
- add broad coverage for auth config, server actions, server queries, API routes, and interaction-heavy UI components
- add GitHub Actions CI to run lint, typecheck, and tests on PRs and feature-branch pushes

## Validation
- npm run test
- npm run lint
- npm run typecheck