### PR TITLE
feat(DOS-019): Build event CRUD and link-to-evidence flow

### DIFF
--- a/src/server/actions/__tests__/events.test.ts
+++ b/src/server/actions/__tests__/events.test.ts
@@ -265,6 +265,48 @@ describe("event actions", () => {
       );
     });
 
+    it("re-snaps the existing date when only precision changes", async () => {
+      mockAuthenticatedUser();
+      mockDb.event.findFirst.mockResolvedValue(
+        buildEvent({
+          id: "evt-1",
+          dossier_id: "dos-1",
+          precision: "day",
+          event_date: new Date(Date.UTC(2026, 2, 15)),
+        }),
+      );
+      mockDb.event.update.mockResolvedValue(buildEvent({ id: "evt-1" }));
+
+      await updateEvent({ id: "evt-1", precision: "year" });
+
+      const call = mockDb.event.update.mock.calls[0][0];
+      expect(call.data.precision).toBe("year");
+      expect(call.data.event_date).toEqual(new Date(Date.UTC(2026, 0, 1)));
+    });
+
+    it("rejects a non-unknown precision update when the event has no resolvable date", async () => {
+      mockAuthenticatedUser();
+      mockDb.event.findFirst.mockResolvedValue(
+        buildEvent({
+          id: "evt-1",
+          dossier_id: "dos-1",
+          precision: "unknown",
+          event_date: null,
+        }),
+      );
+
+      const result = await updateEvent({
+        id: "evt-1",
+        precision: "day",
+        eventDate: null,
+      });
+
+      expect(result).toEqual({
+        error: "Event date is required for this precision.",
+      });
+      expect(mockDb.event.update).not.toHaveBeenCalled();
+    });
+
     it("clears the date when switching to unknown precision", async () => {
       mockAuthenticatedUser();
       mockDb.event.findFirst.mockResolvedValue(

--- a/src/server/actions/__tests__/events.test.ts
+++ b/src/server/actions/__tests__/events.test.ts
@@ -1,0 +1,436 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildDossier,
+  buildEntity,
+  buildEvent,
+  buildHighlight,
+} from "@/lib/test-utils/factories";
+import {
+  mockAuth,
+  mockAuthenticatedUser,
+  mockDb,
+  mockRevalidatePath,
+  resetTestMocks,
+} from "@/test/mocks";
+
+vi.mock("@/auth", () => ({ auth: mockAuth }));
+vi.mock("@/lib/db", () => ({ db: mockDb }));
+vi.mock("next/cache", () => ({ revalidatePath: mockRevalidatePath }));
+
+import {
+  createEvent,
+  deleteEvent,
+  linkEventEntity,
+  linkEventHighlight,
+  unlinkEventEntity,
+  unlinkEventHighlight,
+  updateEvent,
+} from "../events";
+
+describe("event actions", () => {
+  beforeEach(() => {
+    resetTestMocks();
+  });
+
+  describe("createEvent", () => {
+    it("requires authentication", async () => {
+      const result = await createEvent({
+        dossierId: "dos-1",
+        title: "Launch",
+      });
+      expect(result).toEqual({ error: "You must be signed in." });
+    });
+
+    it("validates required fields", async () => {
+      mockAuthenticatedUser();
+
+      await expect(
+        createEvent({ dossierId: "", title: "Launch" }),
+      ).resolves.toEqual({ error: "Dossier ID is required." });
+      await expect(
+        createEvent({ dossierId: "dos-1", title: "   " }),
+      ).resolves.toEqual({ error: "Event title is required." });
+      await expect(
+        createEvent({
+          dossierId: "dos-1",
+          title: "Launch",
+          precision: "invalid" as never,
+        }),
+      ).resolves.toEqual({
+        error: "Invalid precision. Must be one of: day, month, year, unknown.",
+      });
+      await expect(
+        createEvent({
+          dossierId: "dos-1",
+          title: "Launch",
+          precision: "day",
+        }),
+      ).resolves.toEqual({ error: "Event date is required for this precision." });
+      await expect(
+        createEvent({
+          dossierId: "dos-1",
+          title: "Launch",
+          confidence: 200,
+        }),
+      ).resolves.toEqual({ error: "Confidence must be between 0 and 100." });
+    });
+
+    it("rejects dossiers outside the current account", async () => {
+      mockAuthenticatedUser();
+      mockDb.dossier.findFirst.mockResolvedValue(null);
+
+      const result = await createEvent({
+        dossierId: "dos-1",
+        title: "Launch",
+      });
+      expect(result).toEqual({ error: "Dossier not found." });
+    });
+
+    it("creates an event with day precision and normalizes the date to UTC midnight", async () => {
+      mockAuthenticatedUser();
+      mockDb.dossier.findFirst.mockResolvedValue(buildDossier({ id: "dos-1" }));
+      mockDb.event.create.mockResolvedValue({ id: "evt-1" });
+
+      const result = await createEvent({
+        dossierId: "dos-1",
+        title: "  Launch  ",
+        description: "  Product launch  ",
+        eventDate: "2026-03-15T14:32:00Z",
+        precision: "day",
+        confidence: 90,
+      });
+
+      expect(result).toEqual({ id: "evt-1" });
+      const call = mockDb.event.create.mock.calls[0][0];
+      expect(call.data.title).toBe("Launch");
+      expect(call.data.description).toBe("Product launch");
+      expect(call.data.precision).toBe("day");
+      expect(call.data.confidence).toBe(90);
+      expect(call.data.event_date).toEqual(new Date(Date.UTC(2026, 2, 15)));
+      expect(mockRevalidatePath).toHaveBeenCalledWith(
+        "/dossiers/dos-1",
+        "layout",
+      );
+    });
+
+    it("normalizes month-precision dates to the first of the month", async () => {
+      mockAuthenticatedUser();
+      mockDb.dossier.findFirst.mockResolvedValue(buildDossier({ id: "dos-1" }));
+      mockDb.event.create.mockResolvedValue({ id: "evt-1" });
+
+      await createEvent({
+        dossierId: "dos-1",
+        title: "Mid-March",
+        eventDate: "2026-03-15",
+        precision: "month",
+      });
+
+      const call = mockDb.event.create.mock.calls[0][0];
+      expect(call.data.event_date).toEqual(new Date(Date.UTC(2026, 2, 1)));
+      expect(call.data.precision).toBe("month");
+    });
+
+    it("normalizes year-precision dates to January 1", async () => {
+      mockAuthenticatedUser();
+      mockDb.dossier.findFirst.mockResolvedValue(buildDossier({ id: "dos-1" }));
+      mockDb.event.create.mockResolvedValue({ id: "evt-1" });
+
+      await createEvent({
+        dossierId: "dos-1",
+        title: "Sometime in 2026",
+        eventDate: "2026-09-20",
+        precision: "year",
+      });
+
+      const call = mockDb.event.create.mock.calls[0][0];
+      expect(call.data.event_date).toEqual(new Date(Date.UTC(2026, 0, 1)));
+      expect(call.data.precision).toBe("year");
+    });
+
+    it("allows unknown-precision events without a date", async () => {
+      mockAuthenticatedUser();
+      mockDb.dossier.findFirst.mockResolvedValue(buildDossier({ id: "dos-1" }));
+      mockDb.event.create.mockResolvedValue({ id: "evt-1" });
+
+      await createEvent({
+        dossierId: "dos-1",
+        title: "Unknown date",
+      });
+
+      const call = mockDb.event.create.mock.calls[0][0];
+      expect(call.data.event_date).toBeNull();
+      expect(call.data.precision).toBe("unknown");
+    });
+
+    it("attaches highlights and entities at creation time after verifying ownership", async () => {
+      mockAuthenticatedUser();
+      mockDb.dossier.findFirst.mockResolvedValue(buildDossier({ id: "dos-1" }));
+      mockDb.highlight.count.mockResolvedValue(2);
+      mockDb.entity.count.mockResolvedValue(1);
+      mockDb.event.create.mockResolvedValue({ id: "evt-1" });
+
+      await createEvent({
+        dossierId: "dos-1",
+        title: "Launch",
+        highlightIds: ["hl-1", "hl-2", "hl-1"],
+        entityIds: ["ent-1"],
+      });
+
+      const call = mockDb.event.create.mock.calls[0][0];
+      expect(call.data.highlights).toEqual({
+        create: [{ highlight_id: "hl-1" }, { highlight_id: "hl-2" }],
+      });
+      expect(call.data.entities).toEqual({
+        create: [{ entity_id: "ent-1" }],
+      });
+      expect(mockDb.highlight.count).toHaveBeenCalledWith({
+        where: {
+          id: { in: ["hl-1", "hl-2"] },
+          source: { dossier_id: "dos-1" },
+        },
+      });
+    });
+
+    it("rejects highlights from other dossiers", async () => {
+      mockAuthenticatedUser();
+      mockDb.dossier.findFirst.mockResolvedValue(buildDossier({ id: "dos-1" }));
+      mockDb.highlight.count.mockResolvedValue(0);
+
+      const result = await createEvent({
+        dossierId: "dos-1",
+        title: "Launch",
+        highlightIds: ["hl-1"],
+      });
+
+      expect(result).toEqual({
+        error: "One or more highlights not found in this dossier.",
+      });
+      expect(mockDb.event.create).not.toHaveBeenCalled();
+    });
+
+    it("rejects claims that do not belong to the dossier", async () => {
+      mockAuthenticatedUser();
+      mockDb.dossier.findFirst.mockResolvedValue(buildDossier({ id: "dos-1" }));
+      mockDb.claim.findFirst.mockResolvedValue(null);
+
+      const result = await createEvent({
+        dossierId: "dos-1",
+        title: "Launch",
+        claimId: "claim-x",
+      });
+
+      expect(result).toEqual({ error: "Claim not found in this dossier." });
+    });
+  });
+
+  describe("updateEvent", () => {
+    it("requires authentication", async () => {
+      const result = await updateEvent({ id: "evt-1", title: "New" });
+      expect(result).toEqual({ error: "You must be signed in." });
+    });
+
+    it("rejects unknown events", async () => {
+      mockAuthenticatedUser();
+      mockDb.event.findFirst.mockResolvedValue(null);
+
+      const result = await updateEvent({ id: "evt-1", title: "New" });
+      expect(result).toEqual({ error: "Event not found." });
+    });
+
+    it("updates fields, normalizes the date to the new precision, and revalidates", async () => {
+      mockAuthenticatedUser();
+      mockDb.event.findFirst.mockResolvedValue(
+        buildEvent({ id: "evt-1", dossier_id: "dos-1", precision: "day" }),
+      );
+      mockDb.event.update.mockResolvedValue(buildEvent({ id: "evt-1" }));
+
+      const result = await updateEvent({
+        id: "evt-1",
+        title: "Updated",
+        precision: "month",
+        eventDate: "2026-03-15",
+        confidence: 50,
+      });
+
+      expect(result).toEqual({ success: true });
+      const call = mockDb.event.update.mock.calls[0][0];
+      expect(call.where).toEqual({ id: "evt-1" });
+      expect(call.data.title).toBe("Updated");
+      expect(call.data.precision).toBe("month");
+      expect(call.data.event_date).toEqual(new Date(Date.UTC(2026, 2, 1)));
+      expect(call.data.confidence).toBe(50);
+      expect(mockRevalidatePath).toHaveBeenCalledWith(
+        "/dossiers/dos-1",
+        "layout",
+      );
+    });
+
+    it("clears the date when switching to unknown precision", async () => {
+      mockAuthenticatedUser();
+      mockDb.event.findFirst.mockResolvedValue(
+        buildEvent({ id: "evt-1", dossier_id: "dos-1", precision: "day" }),
+      );
+      mockDb.event.update.mockResolvedValue(buildEvent({ id: "evt-1" }));
+
+      await updateEvent({ id: "evt-1", precision: "unknown" });
+
+      const call = mockDb.event.update.mock.calls[0][0];
+      expect(call.data.precision).toBe("unknown");
+      expect(call.data.event_date).toBeNull();
+    });
+  });
+
+  describe("deleteEvent", () => {
+    it("requires authentication", async () => {
+      const result = await deleteEvent("evt-1");
+      expect(result).toEqual({ error: "You must be signed in." });
+    });
+
+    it("removes owned events", async () => {
+      mockAuthenticatedUser();
+      mockDb.event.findFirst.mockResolvedValue(
+        buildEvent({ id: "evt-1", dossier_id: "dos-1" }),
+      );
+      mockDb.event.delete.mockResolvedValue(buildEvent({ id: "evt-1" }));
+
+      const result = await deleteEvent("evt-1");
+
+      expect(result).toEqual({ success: true });
+      expect(mockDb.event.delete).toHaveBeenCalledWith({ where: { id: "evt-1" } });
+      expect(mockRevalidatePath).toHaveBeenCalledWith(
+        "/dossiers/dos-1",
+        "layout",
+      );
+    });
+  });
+
+  describe("linkEventHighlight", () => {
+    it("verifies the highlight belongs to the same dossier", async () => {
+      mockAuthenticatedUser();
+      mockDb.event.findFirst.mockResolvedValue(
+        buildEvent({ id: "evt-1", dossier_id: "dos-1" }),
+      );
+      mockDb.highlight.findFirst.mockResolvedValue(null);
+
+      const result = await linkEventHighlight({
+        eventId: "evt-1",
+        highlightId: "hl-1",
+      });
+
+      expect(result).toEqual({
+        error: "Highlight not found in this dossier.",
+      });
+    });
+
+    it("upserts the join row when ownership checks pass", async () => {
+      mockAuthenticatedUser();
+      mockDb.event.findFirst.mockResolvedValue(
+        buildEvent({ id: "evt-1", dossier_id: "dos-1" }),
+      );
+      mockDb.highlight.findFirst.mockResolvedValue(
+        buildHighlight({ id: "hl-1" }),
+      );
+
+      const result = await linkEventHighlight({
+        eventId: "evt-1",
+        highlightId: "hl-1",
+      });
+
+      expect(result).toEqual({ success: true });
+      expect(mockDb.eventHighlight.upsert).toHaveBeenCalledWith({
+        where: {
+          event_id_highlight_id: {
+            event_id: "evt-1",
+            highlight_id: "hl-1",
+          },
+        },
+        update: {},
+        create: { event_id: "evt-1", highlight_id: "hl-1" },
+      });
+    });
+  });
+
+  describe("unlinkEventHighlight", () => {
+    it("removes the join row", async () => {
+      mockAuthenticatedUser();
+      mockDb.event.findFirst.mockResolvedValue(
+        buildEvent({ id: "evt-1", dossier_id: "dos-1" }),
+      );
+
+      const result = await unlinkEventHighlight({
+        eventId: "evt-1",
+        highlightId: "hl-1",
+      });
+
+      expect(result).toEqual({ success: true });
+      expect(mockDb.eventHighlight.delete).toHaveBeenCalledWith({
+        where: {
+          event_id_highlight_id: {
+            event_id: "evt-1",
+            highlight_id: "hl-1",
+          },
+        },
+      });
+    });
+  });
+
+  describe("linkEventEntity", () => {
+    it("verifies the entity belongs to the same dossier", async () => {
+      mockAuthenticatedUser();
+      mockDb.event.findFirst.mockResolvedValue(
+        buildEvent({ id: "evt-1", dossier_id: "dos-1" }),
+      );
+      mockDb.entity.findFirst.mockResolvedValue(null);
+
+      const result = await linkEventEntity({
+        eventId: "evt-1",
+        entityId: "ent-1",
+      });
+
+      expect(result).toEqual({ error: "Entity not found in this dossier." });
+    });
+
+    it("upserts the join row when ownership checks pass", async () => {
+      mockAuthenticatedUser();
+      mockDb.event.findFirst.mockResolvedValue(
+        buildEvent({ id: "evt-1", dossier_id: "dos-1" }),
+      );
+      mockDb.entity.findFirst.mockResolvedValue(buildEntity({ id: "ent-1" }));
+
+      const result = await linkEventEntity({
+        eventId: "evt-1",
+        entityId: "ent-1",
+      });
+
+      expect(result).toEqual({ success: true });
+      expect(mockDb.eventEntity.upsert).toHaveBeenCalledWith({
+        where: {
+          event_id_entity_id: { event_id: "evt-1", entity_id: "ent-1" },
+        },
+        update: {},
+        create: { event_id: "evt-1", entity_id: "ent-1" },
+      });
+    });
+  });
+
+  describe("unlinkEventEntity", () => {
+    it("removes the join row", async () => {
+      mockAuthenticatedUser();
+      mockDb.event.findFirst.mockResolvedValue(
+        buildEvent({ id: "evt-1", dossier_id: "dos-1" }),
+      );
+
+      const result = await unlinkEventEntity({
+        eventId: "evt-1",
+        entityId: "ent-1",
+      });
+
+      expect(result).toEqual({ success: true });
+      expect(mockDb.eventEntity.delete).toHaveBeenCalledWith({
+        where: {
+          event_id_entity_id: { event_id: "evt-1", entity_id: "ent-1" },
+        },
+      });
+    });
+  });
+});

--- a/src/server/actions/events.ts
+++ b/src/server/actions/events.ts
@@ -174,11 +174,21 @@ export async function updateEvent(
 
   const event = await db.event.findFirst({
     where: { id: input.id, dossier: { owner_id: session.user.id } },
-    select: { id: true, dossier_id: true, precision: true },
+    select: {
+      id: true,
+      dossier_id: true,
+      precision: true,
+      event_date: true,
+    },
   });
   if (!event) return { error: "Event not found." };
 
   const nextPrecision: EventPrecision = input.precision ?? event.precision;
+  const effectiveDate =
+    input.eventDate !== undefined ? input.eventDate : event.event_date;
+
+  if (nextPrecision !== "unknown" && !effectiveDate)
+    return { error: "Event date is required for this precision." };
 
   if (input.claimId) {
     const claim = await db.claim.findFirst({
@@ -205,10 +215,7 @@ export async function updateEvent(
     data.confidence = input.confidence ?? null;
   if (input.claimId !== undefined) data.claim_id = input.claimId ?? null;
   if (input.eventDate !== undefined || input.precision !== undefined) {
-    data.event_date = normalizeEventDate(
-      input.eventDate ?? undefined,
-      nextPrecision,
-    );
+    data.event_date = normalizeEventDate(effectiveDate, nextPrecision);
   }
 
   try {

--- a/src/server/actions/events.ts
+++ b/src/server/actions/events.ts
@@ -1,0 +1,379 @@
+"use server";
+
+import { auth } from "@/auth";
+import { db } from "@/lib/db";
+import { revalidatePath } from "next/cache";
+import type { EventPrecision } from "@prisma/client";
+
+const VALID_PRECISIONS: EventPrecision[] = ["day", "month", "year", "unknown"];
+
+interface CreateEventInput {
+  dossierId: string;
+  title: string;
+  description?: string | null;
+  eventDate?: string | Date | null;
+  precision?: EventPrecision;
+  confidence?: number | null;
+  claimId?: string | null;
+  highlightIds?: string[];
+  entityIds?: string[];
+}
+
+interface UpdateEventInput {
+  id: string;
+  title?: string;
+  description?: string | null;
+  eventDate?: string | Date | null;
+  precision?: EventPrecision;
+  confidence?: number | null;
+  claimId?: string | null;
+}
+
+interface LinkEventHighlightInput {
+  eventId: string;
+  highlightId: string;
+}
+
+interface LinkEventEntityInput {
+  eventId: string;
+  entityId: string;
+}
+
+function isValidConfidence(value: number | null | undefined): boolean {
+  return value == null || (value >= 0 && value <= 100);
+}
+
+function revalidateDossierPaths(dossierId: string) {
+  revalidatePath(`/dossiers/${dossierId}`, "layout");
+}
+
+/**
+ * Normalize a raw date input to a UTC Date anchored to the precision boundary
+ * (year → Jan 1, month → day 1, day → as given). Returns null if no date given.
+ * For precision "unknown", the stored date is dropped so the event is undated.
+ */
+function normalizeEventDate(
+  raw: string | Date | null | undefined,
+  precision: EventPrecision,
+): Date | null {
+  if (precision === "unknown") return null;
+  if (raw == null || raw === "") return null;
+  const d = raw instanceof Date ? raw : new Date(raw);
+  if (Number.isNaN(d.getTime())) return null;
+
+  if (precision === "year") {
+    return new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  }
+  if (precision === "month") {
+    return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1));
+  }
+  return new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()),
+  );
+}
+
+export async function createEvent(
+  input: CreateEventInput,
+): Promise<{ error: string } | { id: string }> {
+  const session = await auth();
+  if (!session?.user?.id) return { error: "You must be signed in." };
+
+  if (!input.dossierId) return { error: "Dossier ID is required." };
+  if (!input.title?.trim()) return { error: "Event title is required." };
+  const precision: EventPrecision = input.precision ?? "unknown";
+  if (!VALID_PRECISIONS.includes(precision))
+    return {
+      error: `Invalid precision. Must be one of: ${VALID_PRECISIONS.join(", ")}.`,
+    };
+  if (precision !== "unknown" && !input.eventDate)
+    return { error: "Event date is required for this precision." };
+  if (!isValidConfidence(input.confidence))
+    return { error: "Confidence must be between 0 and 100." };
+
+  const dossier = await db.dossier.findFirst({
+    where: { id: input.dossierId, owner_id: session.user.id },
+    select: { id: true },
+  });
+  if (!dossier) return { error: "Dossier not found." };
+
+  if (input.claimId) {
+    const claim = await db.claim.findFirst({
+      where: { id: input.claimId, dossier_id: input.dossierId },
+      select: { id: true },
+    });
+    if (!claim) return { error: "Claim not found in this dossier." };
+  }
+
+  const eventDate = normalizeEventDate(input.eventDate, precision);
+  const highlightIds = [...new Set(input.highlightIds?.filter(Boolean) ?? [])];
+  const entityIds = [...new Set(input.entityIds?.filter(Boolean) ?? [])];
+
+  if (highlightIds.length > 0) {
+    const count = await db.highlight.count({
+      where: {
+        id: { in: highlightIds },
+        source: { dossier_id: input.dossierId },
+      },
+    });
+    if (count !== highlightIds.length)
+      return { error: "One or more highlights not found in this dossier." };
+  }
+
+  if (entityIds.length > 0) {
+    const count = await db.entity.count({
+      where: { id: { in: entityIds }, dossier_id: input.dossierId },
+    });
+    if (count !== entityIds.length)
+      return { error: "One or more entities not found in this dossier." };
+  }
+
+  try {
+    const event = await db.event.create({
+      data: {
+        dossier_id: input.dossierId,
+        title: input.title.trim(),
+        description: input.description?.trim() || null,
+        event_date: eventDate,
+        precision,
+        confidence: input.confidence ?? null,
+        claim_id: input.claimId ?? null,
+        highlights: highlightIds.length
+          ? {
+              create: highlightIds.map((highlight_id) => ({ highlight_id })),
+            }
+          : undefined,
+        entities: entityIds.length
+          ? { create: entityIds.map((entity_id) => ({ entity_id })) }
+          : undefined,
+      },
+      select: { id: true },
+    });
+
+    revalidateDossierPaths(input.dossierId);
+    return { id: event.id };
+  } catch {
+    return { error: "Failed to create event. Please try again." };
+  }
+}
+
+export async function updateEvent(
+  input: UpdateEventInput,
+): Promise<{ error: string } | { success: true }> {
+  const session = await auth();
+  if (!session?.user?.id) return { error: "You must be signed in." };
+
+  if (!input.id) return { error: "Event ID is required." };
+  if (input.title !== undefined && !input.title.trim())
+    return { error: "Event title cannot be empty." };
+  if (input.precision && !VALID_PRECISIONS.includes(input.precision))
+    return {
+      error: `Invalid precision. Must be one of: ${VALID_PRECISIONS.join(", ")}.`,
+    };
+  if (!isValidConfidence(input.confidence))
+    return { error: "Confidence must be between 0 and 100." };
+
+  const event = await db.event.findFirst({
+    where: { id: input.id, dossier: { owner_id: session.user.id } },
+    select: { id: true, dossier_id: true, precision: true },
+  });
+  if (!event) return { error: "Event not found." };
+
+  const nextPrecision: EventPrecision = input.precision ?? event.precision;
+
+  if (input.claimId) {
+    const claim = await db.claim.findFirst({
+      where: { id: input.claimId, dossier_id: event.dossier_id },
+      select: { id: true },
+    });
+    if (!claim) return { error: "Claim not found in this dossier." };
+  }
+
+  const data: {
+    title?: string;
+    description?: string | null;
+    event_date?: Date | null;
+    precision?: EventPrecision;
+    confidence?: number | null;
+    claim_id?: string | null;
+  } = {};
+
+  if (input.title !== undefined) data.title = input.title.trim();
+  if (input.description !== undefined)
+    data.description = input.description?.trim() || null;
+  if (input.precision !== undefined) data.precision = input.precision;
+  if (input.confidence !== undefined)
+    data.confidence = input.confidence ?? null;
+  if (input.claimId !== undefined) data.claim_id = input.claimId ?? null;
+  if (input.eventDate !== undefined || input.precision !== undefined) {
+    data.event_date = normalizeEventDate(
+      input.eventDate ?? undefined,
+      nextPrecision,
+    );
+  }
+
+  try {
+    await db.event.update({ where: { id: input.id }, data });
+    revalidateDossierPaths(event.dossier_id);
+    return { success: true };
+  } catch {
+    return { error: "Failed to update event. Please try again." };
+  }
+}
+
+export async function deleteEvent(
+  id: string,
+): Promise<{ error: string } | { success: true }> {
+  const session = await auth();
+  if (!session?.user?.id) return { error: "You must be signed in." };
+
+  const event = await db.event.findFirst({
+    where: { id, dossier: { owner_id: session.user.id } },
+    select: { id: true, dossier_id: true },
+  });
+  if (!event) return { error: "Event not found." };
+
+  try {
+    await db.event.delete({ where: { id } });
+    revalidateDossierPaths(event.dossier_id);
+    return { success: true };
+  } catch {
+    return { error: "Failed to delete event. Please try again." };
+  }
+}
+
+export async function linkEventHighlight(
+  input: LinkEventHighlightInput,
+): Promise<{ error: string } | { success: true }> {
+  const session = await auth();
+  if (!session?.user?.id) return { error: "You must be signed in." };
+
+  if (!input.eventId) return { error: "Event ID is required." };
+  if (!input.highlightId) return { error: "Highlight ID is required." };
+
+  const event = await db.event.findFirst({
+    where: { id: input.eventId, dossier: { owner_id: session.user.id } },
+    select: { id: true, dossier_id: true },
+  });
+  if (!event) return { error: "Event not found." };
+
+  const highlight = await db.highlight.findFirst({
+    where: {
+      id: input.highlightId,
+      source: { dossier_id: event.dossier_id },
+    },
+    select: { id: true },
+  });
+  if (!highlight) return { error: "Highlight not found in this dossier." };
+
+  try {
+    await db.eventHighlight.upsert({
+      where: {
+        event_id_highlight_id: {
+          event_id: event.id,
+          highlight_id: highlight.id,
+        },
+      },
+      update: {},
+      create: { event_id: event.id, highlight_id: highlight.id },
+    });
+    revalidateDossierPaths(event.dossier_id);
+    return { success: true };
+  } catch {
+    return { error: "Failed to link highlight. Please try again." };
+  }
+}
+
+export async function unlinkEventHighlight(
+  input: LinkEventHighlightInput,
+): Promise<{ error: string } | { success: true }> {
+  const session = await auth();
+  if (!session?.user?.id) return { error: "You must be signed in." };
+
+  const event = await db.event.findFirst({
+    where: { id: input.eventId, dossier: { owner_id: session.user.id } },
+    select: { id: true, dossier_id: true },
+  });
+  if (!event) return { error: "Event not found." };
+
+  try {
+    await db.eventHighlight.delete({
+      where: {
+        event_id_highlight_id: {
+          event_id: input.eventId,
+          highlight_id: input.highlightId,
+        },
+      },
+    });
+    revalidateDossierPaths(event.dossier_id);
+    return { success: true };
+  } catch {
+    return { error: "Failed to unlink highlight. Please try again." };
+  }
+}
+
+export async function linkEventEntity(
+  input: LinkEventEntityInput,
+): Promise<{ error: string } | { success: true }> {
+  const session = await auth();
+  if (!session?.user?.id) return { error: "You must be signed in." };
+
+  if (!input.eventId) return { error: "Event ID is required." };
+  if (!input.entityId) return { error: "Entity ID is required." };
+
+  const event = await db.event.findFirst({
+    where: { id: input.eventId, dossier: { owner_id: session.user.id } },
+    select: { id: true, dossier_id: true },
+  });
+  if (!event) return { error: "Event not found." };
+
+  const entity = await db.entity.findFirst({
+    where: { id: input.entityId, dossier_id: event.dossier_id },
+    select: { id: true },
+  });
+  if (!entity) return { error: "Entity not found in this dossier." };
+
+  try {
+    await db.eventEntity.upsert({
+      where: {
+        event_id_entity_id: {
+          event_id: event.id,
+          entity_id: entity.id,
+        },
+      },
+      update: {},
+      create: { event_id: event.id, entity_id: entity.id },
+    });
+    revalidateDossierPaths(event.dossier_id);
+    return { success: true };
+  } catch {
+    return { error: "Failed to link entity. Please try again." };
+  }
+}
+
+export async function unlinkEventEntity(
+  input: LinkEventEntityInput,
+): Promise<{ error: string } | { success: true }> {
+  const session = await auth();
+  if (!session?.user?.id) return { error: "You must be signed in." };
+
+  const event = await db.event.findFirst({
+    where: { id: input.eventId, dossier: { owner_id: session.user.id } },
+    select: { id: true, dossier_id: true },
+  });
+  if (!event) return { error: "Event not found." };
+
+  try {
+    await db.eventEntity.delete({
+      where: {
+        event_id_entity_id: {
+          event_id: input.eventId,
+          entity_id: input.entityId,
+        },
+      },
+    });
+    revalidateDossierPaths(event.dossier_id);
+    return { success: true };
+  } catch {
+    return { error: "Failed to unlink entity. Please try again." };
+  }
+}

--- a/src/server/queries/events.ts
+++ b/src/server/queries/events.ts
@@ -1,0 +1,63 @@
+import { db } from "@/lib/db";
+
+const eventDetailSelect = {
+  id: true,
+  dossier_id: true,
+  title: true,
+  description: true,
+  event_date: true,
+  precision: true,
+  confidence: true,
+  claim_id: true,
+  created_at: true,
+  updated_at: true,
+  highlights: {
+    select: {
+      highlight: {
+        select: {
+          id: true,
+          quote_text: true,
+          page_number: true,
+          source: {
+            select: { id: true, title: true },
+          },
+        },
+      },
+    },
+  },
+  entities: {
+    select: {
+      entity: {
+        select: { id: true, name: true, type: true },
+      },
+    },
+  },
+} as const;
+
+export async function getEvents(dossierId: string, userId: string) {
+  return db.event.findMany({
+    where: {
+      dossier_id: dossierId,
+      dossier: { owner_id: userId },
+    },
+    orderBy: [{ event_date: "asc" }, { precision: "asc" }, { title: "asc" }],
+    select: eventDetailSelect,
+  });
+}
+
+export type EventListItem = Awaited<ReturnType<typeof getEvents>>[number];
+
+export async function getEvent(
+  dossierId: string,
+  eventId: string,
+  userId: string,
+) {
+  return db.event.findFirst({
+    where: {
+      id: eventId,
+      dossier_id: dossierId,
+      dossier: { owner_id: userId },
+    },
+    select: eventDetailSelect,
+  });
+}

--- a/src/test/mocks.ts
+++ b/src/test/mocks.ts
@@ -28,16 +28,21 @@ export const mockDb = {
     ["findFirst", "findMany", "create", "update", "delete"] as const,
   ),
   highlight: createDelegate(
-    ["findFirst", "findMany", "create", "delete"] as const,
+    ["findFirst", "findMany", "create", "delete", "count"] as const,
   ),
   claim: createDelegate(
     ["findFirst", "findMany", "create", "update", "delete"] as const,
   ),
   entity: createDelegate(
-    ["findFirst", "findMany", "create", "update", "delete"] as const,
+    ["findFirst", "findMany", "create", "update", "delete", "count"] as const,
   ),
   mention: createDelegate(["findFirst", "create"] as const),
   claimEntity: createDelegate(["upsert"] as const),
+  event: createDelegate(
+    ["findFirst", "findMany", "create", "update", "delete"] as const,
+  ),
+  eventHighlight: createDelegate(["upsert", "delete"] as const),
+  eventEntity: createDelegate(["upsert", "delete"] as const),
 } as const;
 
 function resetDelegate(delegate: MockDelegate) {
@@ -69,6 +74,9 @@ export function resetTestMocks() {
   resetDelegate(mockDb.entity);
   resetDelegate(mockDb.mention);
   resetDelegate(mockDb.claimEntity);
+  resetDelegate(mockDb.event);
+  resetDelegate(mockDb.eventHighlight);
+  resetDelegate(mockDb.eventEntity);
 }
 
 export function mockAuthenticatedUser(userId = "user-1") {


### PR DESCRIPTION
## Summary

- Add server actions for event CRUD (`createEvent`, `updateEvent`, `deleteEvent`) with support for `day` / `month` / `year` / `unknown` date precision
- Normalize `event_date` to the precision boundary on write (year → Jan 1, month → 1st, day → UTC midnight; `unknown` clears the date) so the Timeline UI (DOS-020) can render partial dates without guessing
- Add link/unlink server actions for attaching highlights and entities to events, with cross-dossier ownership checks
- Add `getEvents` / `getEvent` queries returning linked highlights and entities for downstream UI
- Extend test mocks to cover `event`, `eventHighlight`, `eventEntity`, plus `highlight.count` and `entity.count` for bulk ownership checks

Closes #19

## Validation

- [x] Code builds successfully (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass — 151 total, 22 new (`npm run test`)
- [ ] UI validation — deferred to DOS-020 (timeline view)