### PR TITLE
feat(DOS-021): Build brief persistence and editor shell

### DIFF
--- a/src/app/dossiers/[id]/brief/page.tsx
+++ b/src/app/dossiers/[id]/brief/page.tsx
@@ -1,49 +1,38 @@
 import type { Metadata } from "next";
+import { notFound, redirect } from "next/navigation";
+import { auth } from "@/auth";
+import { getOrCreateBrief } from "@/server/queries/briefs";
+import { BriefEditorClient } from "@/components/briefs/BriefEditorClient";
 
 export const metadata: Metadata = {
   title: "Brief — Dossier",
 };
 
-export default function BriefPage() {
-  return (
-    <div
-      className="w-full max-w-[760px] mx-auto py-8"
-      style={{ paddingInline: "var(--space-gutter)" }}
-    >
-      <div className="flex items-center justify-between mb-6">
-        <h2
-          style={{
-            fontFamily: "var(--font-display)",
-            fontSize: "1.125rem",
-            color: "var(--color-ink-primary)",
-          }}
-        >
-          Brief
-        </h2>
-      </div>
+interface BriefPageProps {
+  params: Promise<{ id: string }>;
+}
 
-      <div className="panel py-12 px-8 text-center">
-        <p
-          className="mb-2 max-w-none"
-          style={{
-            fontFamily: "var(--font-mono)",
-            fontSize: "0.8125rem",
-            color: "var(--color-ink-secondary)",
-          }}
-        >
-          No brief drafted.
-        </p>
-        <p
-          style={{
-            fontFamily: "var(--font-sans)",
-            fontSize: "0.875rem",
-            color: "var(--color-ink-secondary)",
-            fontStyle: "italic",
-          }}
-        >
-          The brief is the final output of your research — a source-backed document drawn from your claims and evidence.
-        </p>
-      </div>
-    </div>
+export default async function BriefPage({ params }: BriefPageProps) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    redirect("/login");
+  }
+
+  const { id } = await params;
+  const brief = await getOrCreateBrief(id, session.user.id);
+
+  if (!brief) {
+    notFound();
+  }
+
+  return (
+    <BriefEditorClient
+      dossierId={id}
+      brief={{
+        title: brief.title,
+        body_markdown: brief.body_markdown,
+        updated_at: brief.updated_at,
+      }}
+    />
   );
 }

--- a/src/components/briefs/BriefEditorClient.tsx
+++ b/src/components/briefs/BriefEditorClient.tsx
@@ -1,0 +1,450 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { saveBrief } from "@/server/actions/briefs";
+
+interface BriefSnapshot {
+  title: string;
+  body_markdown: string | null;
+  updated_at: Date | string;
+}
+
+interface BriefEditorClientProps {
+  dossierId: string;
+  brief: BriefSnapshot;
+}
+
+interface OutlineHeading {
+  id: string;
+  depth: number;
+  text: string;
+  lineStart: number;
+  lineEnd: number;
+}
+
+type SaveStatus = "saved" | "dirty" | "saving" | "error";
+
+const AUTOSAVE_DELAY_MS = 800;
+
+function parseOutline(body: string): OutlineHeading[] {
+  if (!body) return [];
+  const lines = body.split("\n");
+  const headings: OutlineHeading[] = [];
+
+  let cursor = 0;
+  lines.forEach((line, index) => {
+    const lineStart = cursor;
+    const lineEnd = cursor + line.length;
+    cursor = lineEnd + 1; // +1 for the newline separator
+
+    const match = /^(#{1,6})\s+(.+?)\s*$/.exec(line);
+    if (!match) return;
+
+    const depth = match[1].length;
+    const text = match[2].trim();
+    if (!text) return;
+
+    headings.push({
+      id: `heading-${index}`,
+      depth,
+      text,
+      lineStart,
+      lineEnd,
+    });
+  });
+
+  return headings;
+}
+
+function formatSavedLabel(updatedAt: Date | string | null): string {
+  if (!updatedAt) return "";
+  const date = updatedAt instanceof Date ? updatedAt : new Date(updatedAt);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export function BriefEditorClient({
+  dossierId,
+  brief,
+}: BriefEditorClientProps) {
+  const [title, setTitle] = useState(brief.title);
+  const [body, setBody] = useState(brief.body_markdown ?? "");
+  const [status, setStatus] = useState<SaveStatus>("saved");
+  const [savedAt, setSavedAt] = useState<Date | string | null>(brief.updated_at);
+  const [error, setError] = useState<string | null>(null);
+  const [isEvidenceOpen, setIsEvidenceOpen] = useState(true);
+
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Track whether the current state has been persisted.
+  const lastPersistedRef = useRef<{ title: string; body: string }>({
+    title: brief.title,
+    body: brief.body_markdown ?? "",
+  });
+
+  const outline = useMemo(() => parseOutline(body), [body]);
+
+  const persist = useCallback(
+    async (nextTitle: string, nextBody: string) => {
+      setStatus("saving");
+      setError(null);
+      const result = await saveBrief({
+        dossierId,
+        title: nextTitle,
+        bodyMarkdown: nextBody,
+      });
+
+      if ("error" in result) {
+        setStatus("error");
+        setError(result.error);
+        return;
+      }
+
+      lastPersistedRef.current = { title: nextTitle, body: nextBody };
+      setSavedAt(result.updatedAt);
+      setStatus((current) => (current === "saving" ? "saved" : current));
+    },
+    [dossierId],
+  );
+
+  // Debounced autosave: schedule a save whenever title/body drifts from the
+  // last persisted snapshot. Any new edit cancels the pending write.
+  useEffect(() => {
+    const trimmedTitle = title.trim();
+    const snapshot = lastPersistedRef.current;
+    if (title === snapshot.title && body === snapshot.body) {
+      return;
+    }
+    if (!trimmedTitle) {
+      setStatus("error");
+      setError("Brief title is required.");
+      return;
+    }
+
+    setStatus("dirty");
+    setError(null);
+    const handle = window.setTimeout(() => {
+      persist(trimmedTitle, body);
+    }, AUTOSAVE_DELAY_MS);
+
+    return () => window.clearTimeout(handle);
+  }, [title, body, persist]);
+
+  // Flush pending edits on unload so we don't lose the last few keystrokes.
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      const snapshot = lastPersistedRef.current;
+      if (title === snapshot.title && body === snapshot.body) return;
+      event.preventDefault();
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [title, body]);
+
+  function scrollToHeading(heading: OutlineHeading) {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    textarea.focus();
+    textarea.setSelectionRange(heading.lineStart, heading.lineEnd);
+
+    // Approximate scroll by line ratio.
+    const totalLines = Math.max(body.split("\n").length, 1);
+    const lineIndex = body.slice(0, heading.lineStart).split("\n").length - 1;
+    const ratio = lineIndex / totalLines;
+    textarea.scrollTop = ratio * textarea.scrollHeight;
+  }
+
+  const statusLabel = (() => {
+    switch (status) {
+      case "saving":
+        return "Saving…";
+      case "dirty":
+        return "Unsaved changes";
+      case "error":
+        return error ?? "Save failed";
+      case "saved":
+      default: {
+        const label = formatSavedLabel(savedAt);
+        return label ? `Saved · ${label}` : "Saved";
+      }
+    }
+  })();
+
+  return (
+    <div className="flex flex-1 min-h-0" style={{ overflow: "hidden" }}>
+      {/* ── Outline rail ── */}
+      <aside
+        aria-label="Brief outline"
+        className="hidden md:flex flex-col shrink-0"
+        style={{
+          width: "var(--space-rail-width)",
+          borderRight: "var(--border-thin) solid var(--color-border)",
+          backgroundColor: "var(--color-bg-rail)",
+          overflowY: "auto",
+        }}
+      >
+        <div
+          style={{
+            padding: "0.875rem var(--space-gutter) 0.5rem",
+            borderBottom: "var(--border-hairline) solid var(--color-border)",
+          }}
+        >
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.6875rem",
+              textTransform: "uppercase",
+              letterSpacing: "0.08em",
+              color: "var(--color-ink-secondary)",
+            }}
+          >
+            Outline
+          </span>
+        </div>
+        {outline.length === 0 ? (
+          <p
+            className="max-w-none"
+            style={{
+              padding: "0.75rem var(--space-gutter)",
+              fontFamily: "var(--font-sans)",
+              fontSize: "0.8125rem",
+              color: "var(--color-ink-secondary)",
+              fontStyle: "italic",
+              lineHeight: 1.5,
+            }}
+          >
+            Add headings (e.g. “## Summary”) to build a section outline.
+          </p>
+        ) : (
+          <ul
+            className="list-none"
+            style={{ padding: "0.5rem 0" }}
+          >
+            {outline.map((heading) => (
+              <li key={heading.id}>
+                <button
+                  type="button"
+                  onClick={() => scrollToHeading(heading)}
+                  className="w-full text-left"
+                  style={{
+                    padding: "0.25rem var(--space-gutter)",
+                    paddingLeft: `calc(var(--space-gutter) + ${(heading.depth - 1) * 0.75}rem)`,
+                    fontFamily: "var(--font-sans)",
+                    fontSize:
+                      heading.depth === 1
+                        ? "0.875rem"
+                        : heading.depth === 2
+                          ? "0.8125rem"
+                          : "0.75rem",
+                    fontWeight: heading.depth === 1 ? 500 : 400,
+                    color:
+                      heading.depth <= 2
+                        ? "var(--color-ink-primary)"
+                        : "var(--color-ink-secondary)",
+                    background: "transparent",
+                    border: "none",
+                    cursor: "pointer",
+                    lineHeight: 1.45,
+                  }}
+                >
+                  {heading.text}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </aside>
+
+      {/* ── Writing column ── */}
+      <section
+        className="flex-1 min-w-0 flex flex-col"
+        style={{ overflowY: "auto" }}
+      >
+        <header
+          className="flex items-center justify-between"
+          style={{
+            padding: "0.75rem var(--space-gutter)",
+            borderBottom: "var(--border-hairline) solid var(--color-border)",
+          }}
+        >
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.6875rem",
+              textTransform: "uppercase",
+              letterSpacing: "0.08em",
+              color: "var(--color-ink-secondary)",
+            }}
+          >
+            Brief · Draft
+          </span>
+          <span
+            role="status"
+            aria-live="polite"
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.6875rem",
+              color:
+                status === "error"
+                  ? "var(--color-accent-alert)"
+                  : "var(--color-ink-secondary)",
+            }}
+          >
+            {statusLabel}
+          </span>
+        </header>
+
+        <div
+          className="w-full mx-auto flex-1 flex flex-col"
+          style={{
+            maxWidth: "40rem",
+            padding: "3rem 1.5rem 4rem",
+            gap: "1.25rem",
+          }}
+        >
+          <label className="block">
+            <span className="sr-only">Brief title</span>
+            <input
+              type="text"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              placeholder="Untitled brief"
+              aria-label="Brief title"
+              style={{
+                width: "100%",
+                fontFamily: "var(--font-display)",
+                fontSize: "2rem",
+                fontWeight: 600,
+                letterSpacing: "-0.015em",
+                lineHeight: 1.2,
+                color: "var(--color-ink-primary)",
+                background: "transparent",
+                border: "none",
+                outline: "none",
+                padding: 0,
+              }}
+            />
+          </label>
+
+          <label className="flex-1 flex flex-col">
+            <span className="sr-only">Brief body</span>
+            <textarea
+              ref={textareaRef}
+              value={body}
+              onChange={(event) => setBody(event.target.value)}
+              placeholder={
+                "Start drafting. Use Markdown — headings (##), lists, and inline citations live here.\n\nLater you’ll pull supporting evidence from the drawer on the right."
+              }
+              aria-label="Brief body"
+              spellCheck
+              style={{
+                flex: 1,
+                minHeight: "28rem",
+                width: "100%",
+                resize: "none",
+                fontFamily: "var(--font-sans)",
+                fontSize: "1rem",
+                lineHeight: 1.75,
+                color: "var(--color-ink-primary)",
+                background: "transparent",
+                border: "none",
+                outline: "none",
+                padding: 0,
+              }}
+            />
+          </label>
+        </div>
+      </section>
+
+      {/* ── Evidence drawer shell (populated by DOS-022) ── */}
+      <aside
+        aria-label="Evidence drawer"
+        className="hidden lg:flex flex-col shrink-0"
+        style={{
+          width: isEvidenceOpen ? "20rem" : "2.25rem",
+          borderLeft: "var(--border-thin) solid var(--color-border)",
+          backgroundColor: "var(--color-bg-panel)",
+          transition: "width var(--duration-base) ease",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          className="flex items-center shrink-0"
+          style={{
+            padding: "0.75rem",
+            borderBottom: "var(--border-hairline) solid var(--color-border)",
+            justifyContent: isEvidenceOpen ? "space-between" : "center",
+            gap: "0.5rem",
+          }}
+        >
+          {isEvidenceOpen && (
+            <span
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.6875rem",
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
+                color: "var(--color-ink-secondary)",
+              }}
+            >
+              Evidence
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={() => setIsEvidenceOpen((open) => !open)}
+            aria-expanded={isEvidenceOpen}
+            aria-label={
+              isEvidenceOpen ? "Collapse evidence drawer" : "Expand evidence drawer"
+            }
+            className="btn btn-ghost"
+            style={{
+              padding: "0.125rem 0.375rem",
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.75rem",
+            }}
+          >
+            {isEvidenceOpen ? "›" : "‹"}
+          </button>
+        </div>
+
+        {isEvidenceOpen && (
+          <div
+            style={{
+              padding: "1rem",
+              color: "var(--color-ink-secondary)",
+              fontFamily: "var(--font-sans)",
+              fontSize: "0.8125rem",
+              lineHeight: 1.55,
+            }}
+          >
+            <p className="max-w-none" style={{ marginBottom: "0.75rem" }}>
+              Highlights and claims from this dossier will appear here so you
+              can pull them into the brief as citations.
+            </p>
+            <p
+              className="max-w-none"
+              style={{
+                fontStyle: "italic",
+                color: "var(--color-ink-secondary)",
+                opacity: 0.8,
+              }}
+            >
+              Evidence insertion ships in the next update.
+            </p>
+          </div>
+        )}
+      </aside>
+    </div>
+  );
+}

--- a/src/server/actions/__tests__/briefs.test.ts
+++ b/src/server/actions/__tests__/briefs.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildBrief, buildDossier } from "@/lib/test-utils/factories";
+import {
+  mockAuth,
+  mockAuthenticatedUser,
+  mockDb,
+  resetTestMocks,
+} from "@/test/mocks";
+
+vi.mock("@/auth", () => ({ auth: mockAuth }));
+vi.mock("@/lib/db", () => ({ db: mockDb }));
+
+import { saveBrief } from "../briefs";
+
+describe("brief actions", () => {
+  beforeEach(() => {
+    resetTestMocks();
+  });
+
+  describe("saveBrief", () => {
+    it("requires authentication", async () => {
+      const result = await saveBrief({
+        dossierId: "dos-1",
+        title: "Memo",
+        bodyMarkdown: "",
+      });
+      expect(result).toEqual({ error: "You must be signed in." });
+    });
+
+    it("validates required fields", async () => {
+      mockAuthenticatedUser();
+
+      await expect(
+        saveBrief({ dossierId: "", title: "Memo", bodyMarkdown: "" }),
+      ).resolves.toEqual({ error: "Dossier ID is required." });
+
+      await expect(
+        saveBrief({ dossierId: "dos-1", title: "   ", bodyMarkdown: "" }),
+      ).resolves.toEqual({ error: "Brief title is required." });
+
+      await expect(
+        saveBrief({
+          dossierId: "dos-1",
+          title: "x".repeat(201),
+          bodyMarkdown: "",
+        }),
+      ).resolves.toEqual({
+        error: "Brief title must be under 200 characters.",
+      });
+
+      await expect(
+        saveBrief({
+          dossierId: "dos-1",
+          title: "Memo",
+          bodyMarkdown: "x".repeat(200_001),
+        }),
+      ).resolves.toEqual({ error: "Brief is too long to save." });
+    });
+
+    it("rejects dossiers outside the current account", async () => {
+      mockAuthenticatedUser();
+      mockDb.dossier.findFirst.mockResolvedValue(null);
+
+      const result = await saveBrief({
+        dossierId: "dos-1",
+        title: "Memo",
+        bodyMarkdown: "Draft",
+      });
+      expect(result).toEqual({ error: "Dossier not found." });
+    });
+
+    it("upserts the brief and returns the updated timestamp", async () => {
+      mockAuthenticatedUser();
+      mockDb.dossier.findFirst.mockResolvedValue(buildDossier({ id: "dos-1" }));
+      const updatedAt = new Date("2026-04-21T12:34:56Z");
+      mockDb.brief.upsert.mockResolvedValue(
+        buildBrief({ dossier_id: "dos-1", updated_at: updatedAt }),
+      );
+
+      const result = await saveBrief({
+        dossierId: "dos-1",
+        title: "  Q2 Memo  ",
+        bodyMarkdown: "## Summary\n\nLorem.",
+      });
+
+      expect(result).toEqual({
+        success: true,
+        updatedAt: updatedAt.toISOString(),
+      });
+
+      const call = mockDb.brief.upsert.mock.calls[0][0];
+      expect(call.where).toEqual({ dossier_id: "dos-1" });
+      expect(call.update).toEqual({
+        title: "Q2 Memo",
+        body_markdown: "## Summary\n\nLorem.",
+      });
+      expect(call.create).toEqual({
+        dossier_id: "dos-1",
+        title: "Q2 Memo",
+        body_markdown: "## Summary\n\nLorem.",
+      });
+    });
+
+    it("returns a generic error when the database write fails", async () => {
+      mockAuthenticatedUser();
+      mockDb.dossier.findFirst.mockResolvedValue(buildDossier({ id: "dos-1" }));
+      mockDb.brief.upsert.mockRejectedValue(new Error("boom"));
+
+      const result = await saveBrief({
+        dossierId: "dos-1",
+        title: "Memo",
+        bodyMarkdown: "Draft",
+      });
+
+      expect(result).toEqual({ error: "Failed to save brief. Please try again." });
+    });
+  });
+});

--- a/src/server/actions/briefs.ts
+++ b/src/server/actions/briefs.ts
@@ -1,0 +1,58 @@
+"use server";
+
+import { auth } from "@/auth";
+import { db } from "@/lib/db";
+
+interface SaveBriefInput {
+  dossierId: string;
+  title: string;
+  bodyMarkdown: string;
+}
+
+interface SaveBriefSuccess {
+  success: true;
+  updatedAt: string;
+}
+
+const MAX_TITLE_LENGTH = 200;
+const MAX_BODY_LENGTH = 200_000;
+
+export async function saveBrief(
+  input: SaveBriefInput,
+): Promise<{ error: string } | SaveBriefSuccess> {
+  const session = await auth();
+  if (!session?.user?.id) return { error: "You must be signed in." };
+
+  if (!input.dossierId) return { error: "Dossier ID is required." };
+
+  const title = input.title?.trim() ?? "";
+  if (!title) return { error: "Brief title is required." };
+  if (title.length > MAX_TITLE_LENGTH)
+    return { error: `Brief title must be under ${MAX_TITLE_LENGTH} characters.` };
+
+  const body = input.bodyMarkdown ?? "";
+  if (body.length > MAX_BODY_LENGTH)
+    return { error: "Brief is too long to save." };
+
+  const dossier = await db.dossier.findFirst({
+    where: { id: input.dossierId, owner_id: session.user.id },
+    select: { id: true },
+  });
+  if (!dossier) return { error: "Dossier not found." };
+
+  try {
+    const brief = await db.brief.upsert({
+      where: { dossier_id: dossier.id },
+      update: { title, body_markdown: body },
+      create: {
+        dossier_id: dossier.id,
+        title,
+        body_markdown: body,
+      },
+      select: { updated_at: true },
+    });
+    return { success: true, updatedAt: brief.updated_at.toISOString() };
+  } catch {
+    return { error: "Failed to save brief. Please try again." };
+  }
+}

--- a/src/server/queries/briefs.ts
+++ b/src/server/queries/briefs.ts
@@ -1,0 +1,52 @@
+import { db } from "@/lib/db";
+import type { Brief } from "@prisma/client";
+
+export type { Brief };
+
+const briefSelect = {
+  id: true,
+  dossier_id: true,
+  title: true,
+  body_markdown: true,
+  version: true,
+  status: true,
+  created_at: true,
+  updated_at: true,
+} as const;
+
+export type BriefData = Pick<
+  Brief,
+  | "id"
+  | "dossier_id"
+  | "title"
+  | "body_markdown"
+  | "version"
+  | "status"
+  | "created_at"
+  | "updated_at"
+>;
+
+/**
+ * Return the current brief for a dossier, creating an empty draft the first
+ * time it's requested. Scoped by userId so cross-account access returns null.
+ */
+export async function getOrCreateBrief(
+  dossierId: string,
+  userId: string,
+): Promise<BriefData | null> {
+  const dossier = await db.dossier.findFirst({
+    where: { id: dossierId, owner_id: userId },
+    select: { id: true, title: true, brief: { select: briefSelect } },
+  });
+  if (!dossier) return null;
+  if (dossier.brief) return dossier.brief;
+
+  return db.brief.create({
+    data: {
+      dossier_id: dossier.id,
+      title: dossier.title,
+      body_markdown: null,
+    },
+    select: briefSelect,
+  });
+}

--- a/src/test/mocks.ts
+++ b/src/test/mocks.ts
@@ -43,6 +43,7 @@ export const mockDb = {
   ),
   eventHighlight: createDelegate(["upsert", "delete"] as const),
   eventEntity: createDelegate(["upsert", "delete"] as const),
+  brief: createDelegate(["findFirst", "create", "update", "upsert"] as const),
 } as const;
 
 function resetDelegate(delegate: MockDelegate) {
@@ -77,6 +78,7 @@ export function resetTestMocks() {
   resetDelegate(mockDb.event);
   resetDelegate(mockDb.eventHighlight);
   resetDelegate(mockDb.eventEntity);
+  resetDelegate(mockDb.brief);
 }
 
 export function mockAuthenticatedUser(userId = "user-1") {


### PR DESCRIPTION
## Summary

- Add `getOrCreateBrief` query and `saveBrief` server action to persist one brief per dossier with user-scoped authorization
- Replace the Brief tab placeholder with `BriefEditorClient`, a three-pane editor: headings-based outline rail, Markdown writing column, and collapsible evidence drawer shell
- Wire debounced autosave from the Markdown textarea through the new server action, with save-state indication in the editor chrome
- Cover the new server action with tests in `briefs.test.ts` (auth scoping, create-vs-update paths) and extend shared test mocks accordingly
- Refactor `brief/page.tsx` to fetch/seed the brief server-side and hand off to the client editor, replacing the prior static placeholder

Closes #21

## Validation

- [x] Code builds successfully
- [x] Lint passes
- [x] Typecheck passes
- [ ] Tests pass (if applicable)
- [ ] Matches design direction from product spec
