### PR TITLE
feat(DOS-022): Add citation tokens and evidence insertion in the brief editor

### DIFF
--- a/src/app/dossiers/[id]/brief/page.tsx
+++ b/src/app/dossiers/[id]/brief/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
 import { auth } from "@/auth";
-import { getOrCreateBrief } from "@/server/queries/briefs";
+import { getBriefEvidence, getOrCreateBrief } from "@/server/queries/briefs";
 import { BriefEditorClient } from "@/components/briefs/BriefEditorClient";
 
 export const metadata: Metadata = {
@@ -19,7 +19,10 @@ export default async function BriefPage({ params }: BriefPageProps) {
   }
 
   const { id } = await params;
-  const brief = await getOrCreateBrief(id, session.user.id);
+  const [brief, evidence] = await Promise.all([
+    getOrCreateBrief(id, session.user.id),
+    getBriefEvidence(id, session.user.id),
+  ]);
 
   if (!brief) {
     notFound();
@@ -33,6 +36,7 @@ export default async function BriefPage({ params }: BriefPageProps) {
         body_markdown: brief.body_markdown,
         updated_at: brief.updated_at,
       }}
+      evidence={evidence}
     />
   );
 }

--- a/src/components/briefs/BriefEditorClient.tsx
+++ b/src/components/briefs/BriefEditorClient.tsx
@@ -8,6 +8,19 @@ import {
   useState,
 } from "react";
 import { saveBrief } from "@/server/actions/briefs";
+import type {
+  BriefEvidenceHighlight,
+  BriefEvidenceSource,
+} from "@/server/queries/briefs";
+import {
+  buildCitationHref,
+  buildCitationToken,
+  formatHighlightAnchor,
+  formatSourceShortCode,
+  segmentCitations,
+  type CitationRef,
+} from "@/lib/citations";
+import { CitationToken } from "./CitationToken";
 
 interface BriefSnapshot {
   title: string;
@@ -18,6 +31,7 @@ interface BriefSnapshot {
 interface BriefEditorClientProps {
   dossierId: string;
   brief: BriefSnapshot;
+  evidence: BriefEvidenceSource[];
 }
 
 interface OutlineHeading {
@@ -29,8 +43,18 @@ interface OutlineHeading {
 }
 
 type SaveStatus = "saved" | "dirty" | "saving" | "error";
+type ViewMode = "edit" | "preview";
+type DrawerTab = "highlights" | "sources";
 
 const AUTOSAVE_DELAY_MS = 800;
+
+const HIGHLIGHT_LABEL_NAMES: Record<BriefEvidenceHighlight["label"], string> = {
+  evidence: "Evidence",
+  question: "Question",
+  counterpoint: "Counterpoint",
+  stat: "Stat",
+  quote: "Quote",
+};
 
 function parseOutline(body: string): OutlineHeading[] {
   if (!body) return [];
@@ -72,9 +96,16 @@ function formatSavedLabel(updatedAt: Date | string | null): string {
   });
 }
 
+function truncate(text: string, max: number): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (normalized.length <= max) return normalized;
+  return `${normalized.slice(0, max - 1).trimEnd()}…`;
+}
+
 export function BriefEditorClient({
   dossierId,
   brief,
+  evidence,
 }: BriefEditorClientProps) {
   const [title, setTitle] = useState(brief.title);
   const [body, setBody] = useState(brief.body_markdown ?? "");
@@ -82,8 +113,14 @@ export function BriefEditorClient({
   const [savedAt, setSavedAt] = useState<Date | string | null>(brief.updated_at);
   const [error, setError] = useState<string | null>(null);
   const [isEvidenceOpen, setIsEvidenceOpen] = useState(true);
+  const [mode, setMode] = useState<ViewMode>("edit");
+  const [drawerTab, setDrawerTab] = useState<DrawerTab>("highlights");
+  const [drawerQuery, setDrawerQuery] = useState("");
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  // Track the caret so we can insert at the user's last known cursor even
+  // when the textarea isn't focused (e.g. after clicking a drawer item).
+  const caretRef = useRef<number>((brief.body_markdown ?? "").length);
 
   // Track whether the current state has been persisted.
   const lastPersistedRef = useRef<{ title: string; body: string }>({
@@ -92,6 +129,27 @@ export function BriefEditorClient({
   });
 
   const outline = useMemo(() => parseOutline(body), [body]);
+
+  // Fast id→source lookup for rendering citations in preview mode and for
+  // resolving highlight → source navigation.
+  const sourceIndex = useMemo(() => {
+    const map = new Map<string, BriefEvidenceSource>();
+    for (const source of evidence) map.set(source.id, source);
+    return map;
+  }, [evidence]);
+
+  const highlightIndex = useMemo(() => {
+    const map = new Map<
+      string,
+      { highlight: BriefEvidenceHighlight; source: BriefEvidenceSource }
+    >();
+    for (const source of evidence) {
+      for (const highlight of source.highlights) {
+        map.set(highlight.id, { highlight, source });
+      }
+    }
+    return map;
+  }, [evidence]);
 
   const persist = useCallback(
     async (nextTitle: string, nextBody: string) => {
@@ -164,6 +222,73 @@ export function BriefEditorClient({
     textarea.scrollTop = ratio * textarea.scrollHeight;
   }
 
+  const insertCitation = useCallback(
+    (ref: CitationRef) => {
+      const token = buildCitationToken(ref);
+      setMode("edit");
+
+      setBody((current) => {
+        const caret = Math.min(
+          Math.max(caretRef.current, 0),
+          current.length,
+        );
+        // Pad with a space so the chip doesn't fuse into adjacent text.
+        const prefix = current.slice(0, caret);
+        const suffix = current.slice(caret);
+        const needsLeadingSpace =
+          prefix.length > 0 && !/\s$/.test(prefix);
+        const needsTrailingSpace =
+          suffix.length > 0 && !/^\s/.test(suffix);
+        const insertion =
+          (needsLeadingSpace ? " " : "") +
+          token +
+          (needsTrailingSpace ? " " : "");
+        const nextBody = prefix + insertion + suffix;
+        const nextCaret = prefix.length + insertion.length;
+        caretRef.current = nextCaret;
+
+        // Restore focus and caret position to the textarea after React commits.
+        requestAnimationFrame(() => {
+          const textarea = textareaRef.current;
+          if (!textarea) return;
+          textarea.focus();
+          textarea.setSelectionRange(nextCaret, nextCaret);
+        });
+
+        return nextBody;
+      });
+    },
+    [],
+  );
+
+  const filteredEvidence = useMemo(() => {
+    const q = drawerQuery.trim().toLowerCase();
+    if (!q) return evidence;
+    return evidence
+      .map((source) => {
+        const titleMatches = source.title.toLowerCase().includes(q);
+        const matchedHighlights = source.highlights.filter((highlight) => {
+          const haystack = `${highlight.quote_text} ${
+            highlight.annotation ?? ""
+          }`.toLowerCase();
+          return haystack.includes(q);
+        });
+        if (titleMatches) {
+          return source;
+        }
+        if (matchedHighlights.length > 0) {
+          return { ...source, highlights: matchedHighlights };
+        }
+        return null;
+      })
+      .filter((source): source is BriefEvidenceSource => source !== null);
+  }, [evidence, drawerQuery]);
+
+  const highlightCount = useMemo(
+    () => evidence.reduce((sum, source) => sum + source.highlights.length, 0),
+    [evidence],
+  );
+
   const statusLabel = (() => {
     switch (status) {
       case "saving":
@@ -226,10 +351,7 @@ export function BriefEditorClient({
             Add headings (e.g. “## Summary”) to build a section outline.
           </p>
         ) : (
-          <ul
-            className="list-none"
-            style={{ padding: "0.5rem 0" }}
-          >
+          <ul className="list-none" style={{ padding: "0.5rem 0" }}>
             {outline.map((heading) => (
               <li key={heading.id}>
                 <button
@@ -275,6 +397,7 @@ export function BriefEditorClient({
           style={{
             padding: "0.75rem var(--space-gutter)",
             borderBottom: "var(--border-hairline) solid var(--color-border)",
+            gap: "0.75rem",
           }}
         >
           <span
@@ -286,22 +409,63 @@ export function BriefEditorClient({
               color: "var(--color-ink-secondary)",
             }}
           >
-            Brief · Draft
+            Brief · {mode === "edit" ? "Draft" : "Preview"}
           </span>
-          <span
-            role="status"
-            aria-live="polite"
-            style={{
-              fontFamily: "var(--font-mono)",
-              fontSize: "0.6875rem",
-              color:
-                status === "error"
-                  ? "var(--color-accent-alert)"
-                  : "var(--color-ink-secondary)",
-            }}
-          >
-            {statusLabel}
-          </span>
+          <div className="flex items-center" style={{ gap: "0.75rem" }}>
+            <div
+              role="tablist"
+              aria-label="Brief view mode"
+              className="flex"
+              style={{
+                border: "var(--border-thin) solid var(--color-border)",
+                borderRadius: "var(--radius-sm)",
+                overflow: "hidden",
+              }}
+            >
+              {(["edit", "preview"] as const).map((value) => (
+                <button
+                  key={value}
+                  type="button"
+                  role="tab"
+                  aria-selected={mode === value}
+                  onClick={() => setMode(value)}
+                  style={{
+                    padding: "0.25rem 0.625rem",
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "0.6875rem",
+                    textTransform: "uppercase",
+                    letterSpacing: "0.08em",
+                    border: "none",
+                    cursor: "pointer",
+                    backgroundColor:
+                      mode === value
+                        ? "var(--color-bg-selected)"
+                        : "transparent",
+                    color:
+                      mode === value
+                        ? "var(--color-ink-primary)"
+                        : "var(--color-ink-secondary)",
+                  }}
+                >
+                  {value === "edit" ? "Edit" : "Preview"}
+                </button>
+              ))}
+            </div>
+            <span
+              role="status"
+              aria-live="polite"
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.6875rem",
+                color:
+                  status === "error"
+                    ? "var(--color-accent-alert)"
+                    : "var(--color-ink-secondary)",
+              }}
+            >
+              {statusLabel}
+            </span>
+          </div>
         </header>
 
         <div
@@ -312,66 +476,90 @@ export function BriefEditorClient({
             gap: "1.25rem",
           }}
         >
-          <label className="block">
-            <span className="sr-only">Brief title</span>
-            <input
-              type="text"
-              value={title}
-              onChange={(event) => setTitle(event.target.value)}
-              placeholder="Untitled brief"
-              aria-label="Brief title"
-              style={{
-                width: "100%",
-                fontFamily: "var(--font-display)",
-                fontSize: "2rem",
-                fontWeight: 600,
-                letterSpacing: "-0.015em",
-                lineHeight: 1.2,
-                color: "var(--color-ink-primary)",
-                background: "transparent",
-                border: "none",
-                outline: "none",
-                padding: 0,
-              }}
-            />
-          </label>
+          {mode === "edit" ? (
+            <>
+              <label className="block">
+                <span className="sr-only">Brief title</span>
+                <input
+                  type="text"
+                  value={title}
+                  onChange={(event) => setTitle(event.target.value)}
+                  placeholder="Untitled brief"
+                  aria-label="Brief title"
+                  style={{
+                    width: "100%",
+                    fontFamily: "var(--font-display)",
+                    fontSize: "2rem",
+                    fontWeight: 600,
+                    letterSpacing: "-0.015em",
+                    lineHeight: 1.2,
+                    color: "var(--color-ink-primary)",
+                    background: "transparent",
+                    border: "none",
+                    outline: "none",
+                    padding: 0,
+                  }}
+                />
+              </label>
 
-          <label className="flex-1 flex flex-col">
-            <span className="sr-only">Brief body</span>
-            <textarea
-              ref={textareaRef}
-              value={body}
-              onChange={(event) => setBody(event.target.value)}
-              placeholder={
-                "Start drafting. Use Markdown — headings (##), lists, and inline citations live here.\n\nLater you’ll pull supporting evidence from the drawer on the right."
-              }
-              aria-label="Brief body"
-              spellCheck
-              style={{
-                flex: 1,
-                minHeight: "28rem",
-                width: "100%",
-                resize: "none",
-                fontFamily: "var(--font-sans)",
-                fontSize: "1rem",
-                lineHeight: 1.75,
-                color: "var(--color-ink-primary)",
-                background: "transparent",
-                border: "none",
-                outline: "none",
-                padding: 0,
-              }}
+              <label className="flex-1 flex flex-col">
+                <span className="sr-only">Brief body</span>
+                <textarea
+                  ref={textareaRef}
+                  value={body}
+                  onChange={(event) => {
+                    setBody(event.target.value);
+                    caretRef.current = event.target.selectionStart;
+                  }}
+                  onSelect={(event) => {
+                    caretRef.current = event.currentTarget.selectionStart;
+                  }}
+                  onKeyUp={(event) => {
+                    caretRef.current = event.currentTarget.selectionStart;
+                  }}
+                  onBlur={(event) => {
+                    caretRef.current = event.currentTarget.selectionStart;
+                  }}
+                  placeholder={
+                    "Start drafting. Use Markdown — headings (##), lists, and inline citations live here.\n\nPull supporting evidence from the drawer on the right to drop citations at the cursor."
+                  }
+                  aria-label="Brief body"
+                  spellCheck
+                  style={{
+                    flex: 1,
+                    minHeight: "28rem",
+                    width: "100%",
+                    resize: "none",
+                    fontFamily: "var(--font-sans)",
+                    fontSize: "1rem",
+                    lineHeight: 1.75,
+                    color: "var(--color-ink-primary)",
+                    background: "transparent",
+                    border: "none",
+                    outline: "none",
+                    padding: 0,
+                  }}
+                />
+              </label>
+            </>
+          ) : (
+            <BriefPreview
+              title={title}
+              body={body}
+              dossierId={dossierId}
+              sourceIndex={sourceIndex}
+              highlightIndex={highlightIndex}
             />
-          </label>
+          )}
         </div>
       </section>
 
-      {/* ── Evidence drawer shell (populated by DOS-022) ── */}
+      {/* ── Evidence drawer ── */}
       <aside
         aria-label="Evidence drawer"
         className="hidden lg:flex flex-col shrink-0"
         style={{
-          width: isEvidenceOpen ? "20rem" : "2.25rem",
+          width: isEvidenceOpen ? "22rem" : "2.25rem",
           borderLeft: "var(--border-thin) solid var(--color-border)",
           backgroundColor: "var(--color-bg-panel)",
           transition: "width var(--duration-base) ease",
@@ -405,7 +593,9 @@ export function BriefEditorClient({
             onClick={() => setIsEvidenceOpen((open) => !open)}
             aria-expanded={isEvidenceOpen}
             aria-label={
-              isEvidenceOpen ? "Collapse evidence drawer" : "Expand evidence drawer"
+              isEvidenceOpen
+                ? "Collapse evidence drawer"
+                : "Expand evidence drawer"
             }
             className="btn btn-ghost"
             style={{
@@ -419,32 +609,516 @@ export function BriefEditorClient({
         </div>
 
         {isEvidenceOpen && (
-          <div
-            style={{
-              padding: "1rem",
-              color: "var(--color-ink-secondary)",
-              fontFamily: "var(--font-sans)",
-              fontSize: "0.8125rem",
-              lineHeight: 1.55,
-            }}
-          >
-            <p className="max-w-none" style={{ marginBottom: "0.75rem" }}>
-              Highlights and claims from this dossier will appear here so you
-              can pull them into the brief as citations.
-            </p>
-            <p
-              className="max-w-none"
+          <div className="flex flex-col min-h-0" style={{ flex: 1 }}>
+            <div
+              role="tablist"
+              aria-label="Evidence drawer filter"
+              className="flex shrink-0"
               style={{
-                fontStyle: "italic",
-                color: "var(--color-ink-secondary)",
-                opacity: 0.8,
+                borderBottom:
+                  "var(--border-hairline) solid var(--color-border)",
               }}
             >
-              Evidence insertion ships in the next update.
-            </p>
+              <DrawerTabButton
+                label={`Highlights · ${highlightCount}`}
+                active={drawerTab === "highlights"}
+                onClick={() => setDrawerTab("highlights")}
+              />
+              <DrawerTabButton
+                label={`Sources · ${evidence.length}`}
+                active={drawerTab === "sources"}
+                onClick={() => setDrawerTab("sources")}
+              />
+            </div>
+
+            <div
+              className="shrink-0"
+              style={{
+                padding: "0.5rem 0.75rem",
+                borderBottom:
+                  "var(--border-hairline) solid var(--color-border)",
+              }}
+            >
+              <input
+                type="search"
+                value={drawerQuery}
+                onChange={(event) => setDrawerQuery(event.target.value)}
+                placeholder={
+                  drawerTab === "highlights"
+                    ? "Filter highlights"
+                    : "Filter sources"
+                }
+                aria-label="Filter evidence"
+                className="input"
+                style={{ fontSize: "0.8125rem" }}
+              />
+            </div>
+
+            <div
+              style={{
+                flex: 1,
+                overflowY: "auto",
+                padding: "0.25rem 0",
+              }}
+            >
+              {evidence.length === 0 ? (
+                <DrawerEmptyState
+                  message="No sources in this dossier yet. Capture a source to pull evidence into the brief."
+                />
+              ) : filteredEvidence.length === 0 ? (
+                <DrawerEmptyState message="No matches for that filter." />
+              ) : drawerTab === "highlights" ? (
+                <HighlightList
+                  sources={filteredEvidence}
+                  onInsert={insertCitation}
+                />
+              ) : (
+                <SourceList
+                  sources={filteredEvidence}
+                  onInsert={insertCitation}
+                />
+              )}
+            </div>
           </div>
         )}
       </aside>
     </div>
+  );
+}
+
+function DrawerTabButton({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      style={{
+        flex: 1,
+        padding: "0.5rem 0.75rem",
+        fontFamily: "var(--font-mono)",
+        fontSize: "0.6875rem",
+        textTransform: "uppercase",
+        letterSpacing: "0.08em",
+        color: active
+          ? "var(--color-ink-primary)"
+          : "var(--color-ink-secondary)",
+        backgroundColor: active
+          ? "var(--color-bg-selected)"
+          : "transparent",
+        border: "none",
+        cursor: "pointer",
+        borderBottom: active
+          ? "2px solid var(--color-accent-ink)"
+          : "2px solid transparent",
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+function DrawerEmptyState({ message }: { message: string }) {
+  return (
+    <p
+      className="max-w-none"
+      style={{
+        padding: "1rem 0.875rem",
+        fontFamily: "var(--font-sans)",
+        fontSize: "0.8125rem",
+        color: "var(--color-ink-secondary)",
+        fontStyle: "italic",
+        lineHeight: 1.5,
+      }}
+    >
+      {message}
+    </p>
+  );
+}
+
+function HighlightList({
+  sources,
+  onInsert,
+}: {
+  sources: BriefEvidenceSource[];
+  onInsert: (ref: CitationRef) => void;
+}) {
+  const withHighlights = sources.filter(
+    (source) => source.highlights.length > 0,
+  );
+  if (withHighlights.length === 0) {
+    return (
+      <DrawerEmptyState message="No highlights captured yet. Highlight text in a source to reuse it here." />
+    );
+  }
+
+  return (
+    <ul className="list-none" style={{ margin: 0, padding: 0 }}>
+      {withHighlights.map((source) => (
+        <li key={source.id}>
+          <div
+            style={{
+              padding: "0.5rem 0.875rem 0.25rem",
+              display: "flex",
+              alignItems: "baseline",
+              gap: "0.5rem",
+            }}
+          >
+            <span className="chip" style={{ flexShrink: 0 }}>
+              {formatSourceShortCode(source)}
+            </span>
+            <span
+              title={source.title}
+              style={{
+                fontFamily: "var(--font-sans)",
+                fontSize: "0.8125rem",
+                fontWeight: 500,
+                color: "var(--color-ink-primary)",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {source.title}
+            </span>
+          </div>
+          <ul className="list-none" style={{ margin: 0, padding: 0 }}>
+            {source.highlights.map((highlight) => (
+              <li key={highlight.id}>
+                <HighlightDrawerItem
+                  source={source}
+                  highlight={highlight}
+                  onInsert={onInsert}
+                />
+              </li>
+            ))}
+          </ul>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function HighlightDrawerItem({
+  source,
+  highlight,
+  onInsert,
+}: {
+  source: BriefEvidenceSource;
+  highlight: BriefEvidenceHighlight;
+  onInsert: (ref: CitationRef) => void;
+}) {
+  const anchor = formatHighlightAnchor(highlight);
+  const labelName = HIGHLIGHT_LABEL_NAMES[highlight.label] ?? highlight.label;
+
+  return (
+    <div
+      style={{
+        padding: "0.375rem 0.875rem 0.625rem",
+        borderBottom: "var(--border-hairline) solid var(--color-border)",
+      }}
+    >
+      <blockquote
+        style={{
+          margin: 0,
+          paddingLeft: "0.625rem",
+          borderLeft: "var(--border-rule) solid var(--color-accent-ink)",
+          fontFamily: "var(--font-sans)",
+          fontSize: "0.8125rem",
+          lineHeight: 1.55,
+          color: "var(--color-ink-primary)",
+        }}
+      >
+        {truncate(highlight.quote_text, 180)}
+      </blockquote>
+      {highlight.annotation ? (
+        <p
+          className="max-w-none"
+          style={{
+            marginTop: "0.25rem",
+            paddingLeft: "0.625rem",
+            fontFamily: "var(--font-sans)",
+            fontSize: "0.75rem",
+            color: "var(--color-ink-secondary)",
+            fontStyle: "italic",
+            lineHeight: 1.45,
+          }}
+        >
+          {truncate(highlight.annotation, 160)}
+        </p>
+      ) : null}
+      <div
+        className="flex items-center"
+        style={{
+          marginTop: "0.5rem",
+          gap: "0.5rem",
+          justifyContent: "space-between",
+        }}
+      >
+        <span
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.6875rem",
+            color: "var(--color-ink-secondary)",
+            letterSpacing: "0.02em",
+          }}
+        >
+          {labelName} · {anchor}
+        </span>
+        <button
+          type="button"
+          onClick={() =>
+            onInsert({ kind: "highlight", id: highlight.id })
+          }
+          className="btn btn-ghost"
+          aria-label={`Insert citation for ${source.title}, ${anchor}`}
+          style={{
+            padding: "0.125rem 0.5rem",
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.6875rem",
+            textTransform: "uppercase",
+            letterSpacing: "0.08em",
+          }}
+        >
+          Insert
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function SourceList({
+  sources,
+  onInsert,
+}: {
+  sources: BriefEvidenceSource[];
+  onInsert: (ref: CitationRef) => void;
+}) {
+  return (
+    <ul className="list-none" style={{ margin: 0, padding: 0 }}>
+      {sources.map((source) => (
+        <li
+          key={source.id}
+          style={{
+            padding: "0.625rem 0.875rem",
+            borderBottom: "var(--border-hairline) solid var(--color-border)",
+          }}
+        >
+          <div
+            className="flex items-baseline"
+            style={{ gap: "0.5rem" }}
+          >
+            <span className="chip" style={{ flexShrink: 0 }}>
+              {formatSourceShortCode(source)}
+            </span>
+            <span
+              style={{
+                fontFamily: "var(--font-sans)",
+                fontSize: "0.875rem",
+                fontWeight: 500,
+                color: "var(--color-ink-primary)",
+                lineHeight: 1.4,
+              }}
+            >
+              {source.title}
+            </span>
+          </div>
+          {source.author || source.publisher ? (
+            <p
+              className="max-w-none"
+              style={{
+                marginTop: "0.125rem",
+                fontFamily: "var(--font-sans)",
+                fontSize: "0.75rem",
+                color: "var(--color-ink-secondary)",
+              }}
+            >
+              {[source.author, source.publisher].filter(Boolean).join(" · ")}
+            </p>
+          ) : null}
+          <div
+            className="flex items-center"
+            style={{
+              marginTop: "0.375rem",
+              gap: "0.5rem",
+              justifyContent: "space-between",
+            }}
+          >
+            <span
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.6875rem",
+                color: "var(--color-ink-secondary)",
+              }}
+            >
+              {source.highlights.length} highlight
+              {source.highlights.length === 1 ? "" : "s"}
+            </span>
+            <button
+              type="button"
+              onClick={() => onInsert({ kind: "source", id: source.id })}
+              className="btn btn-ghost"
+              aria-label={`Insert citation for ${source.title}`}
+              style={{
+                padding: "0.125rem 0.5rem",
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.6875rem",
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
+              }}
+            >
+              Insert
+            </button>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function BriefPreview({
+  title,
+  body,
+  dossierId,
+  sourceIndex,
+  highlightIndex,
+}: {
+  title: string;
+  body: string;
+  dossierId: string;
+  sourceIndex: Map<string, BriefEvidenceSource>;
+  highlightIndex: Map<
+    string,
+    { highlight: BriefEvidenceHighlight; source: BriefEvidenceSource }
+  >;
+}) {
+  const segments = useMemo(() => segmentCitations(body), [body]);
+  const displayTitle = title.trim() || "Untitled brief";
+
+  return (
+    <article className="flex-1 flex flex-col" aria-label="Brief preview">
+      <h1
+        style={{
+          fontFamily: "var(--font-display)",
+          fontSize: "2rem",
+          fontWeight: 600,
+          letterSpacing: "-0.015em",
+          lineHeight: 1.2,
+          color: "var(--color-ink-primary)",
+          marginBottom: "1.25rem",
+        }}
+      >
+        {displayTitle}
+      </h1>
+
+      {body.trim() === "" ? (
+        <p
+          className="max-w-none"
+          style={{
+            fontFamily: "var(--font-sans)",
+            fontSize: "0.9375rem",
+            color: "var(--color-ink-secondary)",
+            fontStyle: "italic",
+            lineHeight: 1.55,
+          }}
+        >
+          Nothing to preview yet. Switch back to Edit to start drafting.
+        </p>
+      ) : (
+        <div
+          style={{
+            fontFamily: "var(--font-sans)",
+            fontSize: "1rem",
+            lineHeight: 1.75,
+            color: "var(--color-ink-primary)",
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-word",
+          }}
+        >
+          {segments.map((segment, index) => {
+            if (segment.type === "text") {
+              return <span key={index}>{segment.text}</span>;
+            }
+            return (
+              <CitationChipForRef
+                key={index}
+                ref_={segment.ref}
+                raw={segment.raw}
+                dossierId={dossierId}
+                sourceIndex={sourceIndex}
+                highlightIndex={highlightIndex}
+              />
+            );
+          })}
+        </div>
+      )}
+    </article>
+  );
+}
+
+function CitationChipForRef({
+  ref_,
+  raw,
+  dossierId,
+  sourceIndex,
+  highlightIndex,
+}: {
+  ref_: CitationRef;
+  raw: string;
+  dossierId: string;
+  sourceIndex: Map<string, BriefEvidenceSource>;
+  highlightIndex: Map<
+    string,
+    { highlight: BriefEvidenceHighlight; source: BriefEvidenceSource }
+  >;
+}) {
+  if (ref_.kind === "highlight") {
+    const entry = highlightIndex.get(ref_.id);
+    if (!entry) {
+      return (
+        <CitationToken
+          label="missing"
+          title={`Citation references a removed highlight (${raw}).`}
+        />
+      );
+    }
+    return (
+      <CitationToken
+        label={formatSourceShortCode(entry.source)}
+        anchor={formatHighlightAnchor(entry.highlight)}
+        href={buildCitationHref(dossierId, ref_, {
+          highlightSourceId: entry.source.id,
+        })}
+        title={`${entry.source.title} — “${truncate(
+          entry.highlight.quote_text,
+          120,
+        )}”`}
+      />
+    );
+  }
+
+  const source = sourceIndex.get(ref_.id);
+  if (!source) {
+    return (
+      <CitationToken
+        label="missing"
+        title={`Citation references a removed source (${raw}).`}
+      />
+    );
+  }
+  return (
+    <CitationToken
+      label={formatSourceShortCode(source)}
+      href={buildCitationHref(dossierId, ref_)}
+      title={source.title}
+    />
   );
 }

--- a/src/components/briefs/CitationToken.tsx
+++ b/src/components/briefs/CitationToken.tsx
@@ -1,0 +1,70 @@
+import Link from "next/link";
+
+interface CitationTokenProps {
+  label: string;
+  anchor?: string | null;
+  href?: string | null;
+  title?: string;
+  onNavigate?: () => void;
+}
+
+/**
+ * Small mono chip with muted citation fill. Renders as a link back to the
+ * evidence when an href is provided, or an inert span otherwise (for export
+ * contexts or cases where the underlying record has been removed).
+ */
+export function CitationToken({
+  label,
+  anchor,
+  href,
+  title,
+  onNavigate,
+}: CitationTokenProps) {
+  const content = (
+    <>
+      <span>{label}</span>
+      {anchor ? (
+        <>
+          <span aria-hidden="true" style={{ opacity: 0.5 }}>
+            ·
+          </span>
+          <span>{anchor}</span>
+        </>
+      ) : null}
+    </>
+  );
+
+  const ariaLabel = anchor
+    ? `Citation ${label}, ${anchor}`
+    : `Citation ${label}`;
+
+  if (href) {
+    return (
+      <Link
+        href={href}
+        onClick={onNavigate}
+        className="chip chip-citation"
+        aria-label={ariaLabel}
+        title={title ?? ariaLabel}
+        style={{
+          cursor: "pointer",
+          textDecoration: "none",
+          verticalAlign: "baseline",
+        }}
+      >
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <span
+      className="chip chip-citation"
+      aria-label={ariaLabel}
+      title={title ?? ariaLabel}
+      style={{ verticalAlign: "baseline" }}
+    >
+      {content}
+    </span>
+  );
+}

--- a/src/lib/__tests__/citations.test.ts
+++ b/src/lib/__tests__/citations.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCitationHref,
+  buildCitationToken,
+  formatHighlightAnchor,
+  formatSourceShortCode,
+  segmentCitations,
+} from "../citations";
+
+describe("citations", () => {
+  describe("buildCitationToken", () => {
+    it("formats highlight and source refs as inline markers", () => {
+      expect(buildCitationToken({ kind: "highlight", id: "abc123" })).toBe(
+        "[[cite:highlight:abc123]]",
+      );
+      expect(buildCitationToken({ kind: "source", id: "xyz_9" })).toBe(
+        "[[cite:source:xyz_9]]",
+      );
+    });
+  });
+
+  describe("segmentCitations", () => {
+    it("returns a single empty text segment for empty input", () => {
+      expect(segmentCitations("")).toEqual([{ type: "text", text: "" }]);
+    });
+
+    it("splits body text around citation tokens in order", () => {
+      const body =
+        "Revenue fell 12% [[cite:highlight:h1]] and margins held [[cite:source:s1]].";
+      const segments = segmentCitations(body);
+
+      expect(segments).toEqual([
+        { type: "text", text: "Revenue fell 12% " },
+        {
+          type: "citation",
+          raw: "[[cite:highlight:h1]]",
+          ref: { kind: "highlight", id: "h1" },
+        },
+        { type: "text", text: " and margins held " },
+        {
+          type: "citation",
+          raw: "[[cite:source:s1]]",
+          ref: { kind: "source", id: "s1" },
+        },
+        { type: "text", text: "." },
+      ]);
+    });
+
+    it("handles adjacent citation tokens and leading/trailing text", () => {
+      const body = "[[cite:highlight:a]][[cite:source:b]] tail";
+      const segments = segmentCitations(body);
+
+      expect(segments).toEqual([
+        {
+          type: "citation",
+          raw: "[[cite:highlight:a]]",
+          ref: { kind: "highlight", id: "a" },
+        },
+        {
+          type: "citation",
+          raw: "[[cite:source:b]]",
+          ref: { kind: "source", id: "b" },
+        },
+        { type: "text", text: " tail" },
+      ]);
+    });
+
+    it("ignores malformed markers", () => {
+      const body = "Random [cite:foo] text [[cite:bogus:x]] end";
+      const segments = segmentCitations(body);
+
+      expect(segments).toEqual([
+        { type: "text", text: "Random [cite:foo] text [[cite:bogus:x]] end" },
+      ]);
+    });
+
+    it("does not share regex state across calls", () => {
+      const body = "prefix [[cite:source:a]] suffix";
+      const first = segmentCitations(body);
+      const second = segmentCitations(body);
+      expect(first).toEqual(second);
+    });
+  });
+
+  describe("formatSourceShortCode", () => {
+    it("uses two-word initials when available", () => {
+      expect(
+        formatSourceShortCode({ id: "cuid123", title: "Quarterly Report" }),
+      ).toBe("QR");
+    });
+
+    it("falls back to 3-letter slice for single words", () => {
+      expect(
+        formatSourceShortCode({ id: "cuid123", title: "Memo" }),
+      ).toBe("MEM");
+    });
+
+    it("falls back to trailing id characters when title is empty", () => {
+      expect(
+        formatSourceShortCode({ id: "abcdefghij", title: "" }),
+      ).toBe("GHIJ");
+      expect(
+        formatSourceShortCode({ id: "abcdefghij", title: null }),
+      ).toBe("GHIJ");
+    });
+
+    it("strips punctuation so 'U.S. Strategy' becomes US", () => {
+      expect(
+        formatSourceShortCode({ id: "cuid1", title: "U.S. Strategy" }),
+      ).toBe("US");
+    });
+  });
+
+  describe("formatHighlightAnchor", () => {
+    it("uses page numbers when present", () => {
+      expect(
+        formatHighlightAnchor({
+          page_number: 7,
+          start_offset: 10_000,
+        }),
+      ).toBe("p.7");
+    });
+
+    it("approximates paragraph number from offset when page is missing", () => {
+      expect(
+        formatHighlightAnchor({
+          page_number: null,
+          start_offset: 0,
+        }),
+      ).toBe("¶1");
+      expect(
+        formatHighlightAnchor({
+          page_number: null,
+          start_offset: 1200,
+        }),
+      ).toBe("¶4");
+    });
+  });
+
+  describe("buildCitationHref", () => {
+    it("points source citations at the reader hash anchor", () => {
+      expect(
+        buildCitationHref("dos1", { kind: "source", id: "src1" }),
+      ).toBe("/dossiers/dos1/sources/src1#source-context");
+    });
+
+    it("points highlight citations at the source reader with highlight param", () => {
+      expect(
+        buildCitationHref(
+          "dos1",
+          { kind: "highlight", id: "h1" },
+          { highlightSourceId: "src1" },
+        ),
+      ).toBe(
+        "/dossiers/dos1/sources/src1?highlight=h1#source-context",
+      );
+    });
+
+    it("returns null when the highlight's source is unknown", () => {
+      expect(
+        buildCitationHref("dos1", { kind: "highlight", id: "h1" }),
+      ).toBeNull();
+    });
+  });
+});

--- a/src/lib/citations.ts
+++ b/src/lib/citations.ts
@@ -1,0 +1,116 @@
+/**
+ * Brief citation tokens are stored inline inside `body_markdown` as a compact
+ * text marker so they survive plain-text editing and persistence. The marker
+ * format:
+ *
+ *   [[cite:highlight:<highlightId>]]
+ *   [[cite:source:<sourceId>]]
+ *
+ * The client segments the body at these markers to render inline
+ * `CitationToken` chips in the editor preview, and exports parse the same
+ * format to render human-readable citations.
+ */
+
+export type CitationKind = "highlight" | "source";
+
+export interface CitationRef {
+  kind: CitationKind;
+  id: string;
+}
+
+// Matches [[cite:highlight:abc123]] / [[cite:source:abc123]]. IDs are cuid-like
+// and contain only letters, digits, underscores and dashes.
+const CITATION_TOKEN_PATTERN = /\[\[cite:(highlight|source):([A-Za-z0-9_-]+)\]\]/g;
+
+export function buildCitationToken(ref: CitationRef): string {
+  return `[[cite:${ref.kind}:${ref.id}]]`;
+}
+
+export type CitationSegment =
+  | { type: "text"; text: string }
+  | { type: "citation"; ref: CitationRef; raw: string };
+
+/**
+ * Split a body string into plain-text segments and citation refs in
+ * left-to-right order. Always returns a non-empty array (at minimum a single
+ * text segment, which may be empty).
+ */
+export function segmentCitations(body: string): CitationSegment[] {
+  const segments: CitationSegment[] = [];
+  let cursor = 0;
+
+  // Use a fresh regex instance so we don't share lastIndex across calls.
+  const pattern = new RegExp(CITATION_TOKEN_PATTERN.source, "g");
+  for (const match of body.matchAll(pattern)) {
+    const start = match.index ?? 0;
+    if (start > cursor) {
+      segments.push({ type: "text", text: body.slice(cursor, start) });
+    }
+    segments.push({
+      type: "citation",
+      raw: match[0],
+      ref: { kind: match[1] as CitationKind, id: match[2] },
+    });
+    cursor = start + match[0].length;
+  }
+
+  if (cursor < body.length) {
+    segments.push({ type: "text", text: body.slice(cursor) });
+  }
+  if (segments.length === 0) {
+    segments.push({ type: "text", text: "" });
+  }
+
+  return segments;
+}
+
+/**
+ * Short identifier suitable for display in a citation chip. Prefers visible
+ * letters from the source title so the chip stays meaningful without
+ * leaking the cuid. Falls back to the trailing characters of the id.
+ */
+export function formatSourceShortCode(
+  source: { id: string; title: string | null },
+): string {
+  const cleanedTitle = (source.title ?? "").replace(/[^\p{L}\p{N}]+/gu, " ").trim();
+  if (cleanedTitle) {
+    const tokens = cleanedTitle.split(/\s+/).filter(Boolean);
+    if (tokens.length >= 2) {
+      return (tokens[0][0]! + tokens[1][0]!).toUpperCase();
+    }
+    return tokens[0].slice(0, 3).toUpperCase();
+  }
+  return source.id.slice(-4).toUpperCase();
+}
+
+export function formatHighlightAnchor(highlight: {
+  page_number: number | null;
+  start_offset: number;
+  quote_text?: string | null;
+}): string {
+  if (typeof highlight.page_number === "number") {
+    return `p.${highlight.page_number}`;
+  }
+  // Rough paragraph approximation: one paragraph per ~400 chars. Stable and
+  // useful as a rough anchor even without page data.
+  const paragraph = Math.max(1, Math.floor(highlight.start_offset / 400) + 1);
+  return `¶${paragraph}`;
+}
+
+export function buildCitationHref(
+  dossierId: string,
+  ref: CitationRef,
+  context: {
+    highlightSourceId?: string | null;
+  } = {},
+): string | null {
+  if (ref.kind === "source") {
+    return `/dossiers/${dossierId}/sources/${ref.id}#source-context`;
+  }
+  if (ref.kind === "highlight") {
+    if (!context.highlightSourceId) return null;
+    const params = new URLSearchParams({ highlight: ref.id });
+    return `/dossiers/${dossierId}/sources/${context.highlightSourceId}?${params.toString()}#source-context`;
+  }
+  return null;
+}

--- a/src/server/queries/briefs.ts
+++ b/src/server/queries/briefs.ts
@@ -50,3 +50,45 @@ export async function getOrCreateBrief(
     select: briefSelect,
   });
 }
+
+/**
+ * Fetch the evidence pool available to the brief editor: every source in the
+ * dossier, each with its highlights. Used to populate the evidence drawer
+ * where users pick citations to insert into the brief body.
+ */
+export async function getBriefEvidence(dossierId: string, userId: string) {
+  const sources = await db.source.findMany({
+    where: {
+      dossier_id: dossierId,
+      dossier: { owner_id: userId },
+    },
+    orderBy: [{ captured_at: "desc" }, { title: "asc" }],
+    select: {
+      id: true,
+      title: true,
+      type: true,
+      author: true,
+      publisher: true,
+      captured_at: true,
+      highlights: {
+        orderBy: { start_offset: "asc" },
+        select: {
+          id: true,
+          source_id: true,
+          quote_text: true,
+          start_offset: true,
+          end_offset: true,
+          page_number: true,
+          label: true,
+          annotation: true,
+        },
+      },
+    },
+  });
+  return sources;
+}
+
+export type BriefEvidenceSource = Awaited<
+  ReturnType<typeof getBriefEvidence>
+>[number];
+export type BriefEvidenceHighlight = BriefEvidenceSource["highlights"][number];


### PR DESCRIPTION
## Summary

- Introduce `[[cite:kind:id]]` inline token format with helpers in `src/lib/citations.ts` for segmenting, building, and resolving citation markers stored in `body_markdown`
- Add `CitationToken` mono chip component that renders citations inline and links back to the underlying source or highlight in the reader
- Populate the brief evidence drawer with dossier sources and highlights, including search filtering and Insert actions that drop a token at the caret position
- Add an Edit/Preview mode toggle to the brief editor so citations render as chips alongside drafted prose
- Extend brief queries with `getBriefEvidence` and add unit test coverage for the citation helpers

Closes #22

## Validation

- [x] Code builds successfully
- [x] Lint passes
- [x] Typecheck passes
- [ ] Tests pass (if applicable)
- [ ] Matches design direction from product spec
