### PR TITLE
feat(DOS-023): Build global search across core objects

### DIFF
--- a/prisma/migrations/20260421000000_add_search_indexes/migration.sql
+++ b/prisma/migrations/20260421000000_add_search_indexes/migration.sql
@@ -1,0 +1,56 @@
+-- Full-text search GIN indexes for global workspace search.
+-- Uses the 'simple' config so proper nouns and research-specific terms
+-- are matched without English-language stemming.
+
+CREATE INDEX "dossiers_fts_idx" ON "dossiers" USING GIN (
+  to_tsvector(
+    'simple',
+    coalesce("title", '') || ' ' ||
+    coalesce("summary", '') || ' ' ||
+    coalesce("research_goal", '')
+  )
+);
+
+CREATE INDEX "sources_fts_idx" ON "sources" USING GIN (
+  to_tsvector(
+    'simple',
+    coalesce("title", '') || ' ' ||
+    coalesce("author", '') || ' ' ||
+    coalesce("publisher", '') || ' ' ||
+    coalesce("summary", '') || ' ' ||
+    coalesce("raw_text", '')
+  )
+);
+
+CREATE INDEX "highlights_fts_idx" ON "highlights" USING GIN (
+  to_tsvector(
+    'simple',
+    coalesce("quote_text", '') || ' ' ||
+    coalesce("annotation", '')
+  )
+);
+
+CREATE INDEX "claims_fts_idx" ON "claims" USING GIN (
+  to_tsvector(
+    'simple',
+    coalesce("statement", '') || ' ' ||
+    coalesce("notes", '')
+  )
+);
+
+CREATE INDEX "entities_fts_idx" ON "entities" USING GIN (
+  to_tsvector(
+    'simple',
+    coalesce("name", '') || ' ' ||
+    coalesce("description", '') || ' ' ||
+    array_to_string("aliases", ' ')
+  )
+);
+
+CREATE INDEX "briefs_fts_idx" ON "briefs" USING GIN (
+  to_tsvector(
+    'simple',
+    coalesce("title", '') || ' ' ||
+    coalesce("body_markdown", '')
+  )
+);

--- a/src/app/api/search/route.test.ts
+++ b/src/app/api/search/route.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockAuth, mockAuthenticatedUser, resetTestMocks } from "@/test/mocks";
+
+const { mockSearchWorkspace } = vi.hoisted(() => ({
+  mockSearchWorkspace: vi.fn(),
+}));
+
+vi.mock("@/auth", () => ({ auth: mockAuth }));
+vi.mock("@/server/queries/search", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/server/queries/search")
+  >("@/server/queries/search");
+  return {
+    ...actual,
+    searchWorkspace: mockSearchWorkspace,
+  };
+});
+
+import { GET } from "./route";
+
+function makeRequest(url: string) {
+  return { url } as never;
+}
+
+describe("GET /api/search", () => {
+  beforeEach(() => {
+    resetTestMocks();
+    mockSearchWorkspace.mockReset();
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    const response = await GET(makeRequest("https://example.com/api/search?q=alpha"));
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(mockSearchWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("delegates to searchWorkspace with the parsed query and dossier scope", async () => {
+    mockAuthenticatedUser("user-1");
+    const fake = {
+      query: "alpha",
+      dossierId: "dos-1",
+      types: ["dossier"],
+      groups: {
+        dossier: [],
+        source: [],
+        highlight: [],
+        claim: [],
+        entity: [],
+        brief: [],
+      },
+      total: 0,
+    };
+    mockSearchWorkspace.mockResolvedValue(fake);
+
+    const response = await GET(
+      makeRequest(
+        "https://example.com/api/search?q=alpha&dossierId=dos-1&types=dossier,unknown",
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockSearchWorkspace).toHaveBeenCalledWith("user-1", "alpha", {
+      dossierId: "dos-1",
+      types: ["dossier"],
+    });
+    await expect(response.json()).resolves.toEqual(fake);
+  });
+
+  it("returns an empty result when the query is blank", async () => {
+    mockAuthenticatedUser("user-1");
+    mockSearchWorkspace.mockResolvedValue({
+      query: "",
+      dossierId: null,
+      types: [],
+      groups: {
+        dossier: [],
+        source: [],
+        highlight: [],
+        claim: [],
+        entity: [],
+        brief: [],
+      },
+      total: 0,
+    });
+
+    const response = await GET(makeRequest("https://example.com/api/search"));
+
+    expect(response.status).toBe(200);
+    expect(mockSearchWorkspace).toHaveBeenCalledWith("user-1", "", {
+      dossierId: null,
+      types: undefined,
+    });
+  });
+});

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import {
+  SEARCH_OBJECT_TYPES,
+  searchWorkspace,
+  type SearchObjectType,
+} from "@/server/queries/search";
+
+const VALID_TYPES = new Set<SearchObjectType>(SEARCH_OBJECT_TYPES);
+
+export async function GET(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const query = searchParams.get("q")?.trim() ?? "";
+  const dossierId = searchParams.get("dossierId")?.trim() || null;
+  const typesParam = searchParams.get("types")?.trim();
+
+  const types = typesParam
+    ? typesParam
+        .split(",")
+        .map((t) => t.trim())
+        .filter((t): t is SearchObjectType =>
+          VALID_TYPES.has(t as SearchObjectType),
+        )
+    : undefined;
+
+  const results = await searchWorkspace(session.user.id, query, {
+    dossierId,
+    types,
+  });
+
+  return NextResponse.json(results);
+}

--- a/src/app/dossiers/[id]/layout.tsx
+++ b/src/app/dossiers/[id]/layout.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { auth } from "@/auth";
 import { getDossier } from "@/server/queries/dossiers";
 import { WorkspaceTabBar } from "@/components/dossiers/WorkspaceTabBar";
+import { GlobalSearchBar } from "@/components/search/GlobalSearchBar";
 
 interface DossierLayoutProps {
   children: React.ReactNode;
@@ -80,6 +81,10 @@ export default async function DossierLayout({
           >
             {dossier.status}
           </span>
+        </div>
+
+        <div className="flex-1 flex justify-end min-w-0">
+          <GlobalSearchBar dossierId={id} />
         </div>
       </header>
 

--- a/src/app/dossiers/page.tsx
+++ b/src/app/dossiers/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { auth, signOut } from "@/auth";
 import { getDossiers } from "@/server/queries/dossiers";
 import { DossiersClient } from "@/components/dossiers/DossiersClient";
+import { GlobalSearchBar } from "@/components/search/GlobalSearchBar";
 
 export const metadata: Metadata = {
   title: "Dossiers — Dossier",
@@ -68,6 +69,10 @@ export default async function DossiersPage() {
               Sign out
             </button>
           </form>
+        </div>
+
+        <div style={{ marginBottom: "1.5rem" }}>
+          <GlobalSearchBar />
         </div>
 
         <DossiersClient dossiers={dossiers} />

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,132 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { auth } from "@/auth";
+import { getDossier } from "@/server/queries/dossiers";
+import { searchWorkspace } from "@/server/queries/search";
+import { GlobalSearchBar } from "@/components/search/GlobalSearchBar";
+import { SearchResults } from "@/components/search/SearchResults";
+
+export const metadata: Metadata = {
+  title: "Search — Dossier",
+};
+
+interface SearchPageProps {
+  searchParams: Promise<{
+    q?: string;
+    dossierId?: string;
+  }>;
+}
+
+export default async function SearchPage({ searchParams }: SearchPageProps) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    redirect("/login");
+  }
+
+  const { q, dossierId } = await searchParams;
+  const query = q?.trim() ?? "";
+
+  // Validate the scoped dossier — if the id is unknown to this user, drop the
+  // scope rather than silently returning empty results.
+  let scopedDossier = null;
+  if (dossierId) {
+    scopedDossier = await getDossier(dossierId, session.user.id);
+  }
+  const effectiveDossierId = scopedDossier?.id ?? null;
+
+  const results = query
+    ? await searchWorkspace(session.user.id, query, {
+        dossierId: effectiveDossierId,
+      })
+    : {
+        query: "",
+        dossierId: effectiveDossierId,
+        types: [],
+        groups: {
+          dossier: [],
+          source: [],
+          highlight: [],
+          claim: [],
+          entity: [],
+          brief: [],
+        },
+        total: 0,
+      };
+
+  return (
+    <main
+      style={{
+        minHeight: "100dvh",
+        backgroundColor: "var(--color-bg-canvas)",
+        padding: "2rem var(--space-gutter)",
+      }}
+    >
+      <div style={{ maxWidth: "var(--space-content-max)", marginInline: "auto" }}>
+        <div style={{ marginBottom: "1.5rem" }}>
+          <Link
+            href={
+              scopedDossier
+                ? `/dossiers/${scopedDossier.id}/overview`
+                : "/dossiers"
+            }
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.75rem",
+              color: "var(--color-ink-secondary)",
+            }}
+          >
+            ← {scopedDossier ? scopedDossier.title : "Dossiers"}
+          </Link>
+        </div>
+
+        <header
+          style={{
+            marginBottom: "1.5rem",
+            paddingBottom: "1rem",
+            borderBottom: "var(--border-thin) solid var(--color-border)",
+          }}
+        >
+          <h1
+            style={{
+              fontFamily: "var(--font-display)",
+              fontSize: "1.75rem",
+              color: "var(--color-ink-primary)",
+              marginBottom: "0.75rem",
+            }}
+          >
+            Search
+          </h1>
+          <GlobalSearchBar
+            dossierId={scopedDossier?.id}
+            initialQuery={query}
+          />
+          {scopedDossier && (
+            <p
+              style={{
+                marginTop: "0.5rem",
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.75rem",
+                color: "var(--color-ink-secondary)",
+              }}
+            >
+              Scoped to{" "}
+              <span style={{ color: "var(--color-accent-ink)" }}>
+                {scopedDossier.title}
+              </span>
+              {" · "}
+              <Link href={`/search?q=${encodeURIComponent(query)}`}>
+                search all dossiers
+              </Link>
+            </p>
+          )}
+        </header>
+
+        <SearchResults
+          results={results}
+          dossierTitle={scopedDossier?.title ?? null}
+        />
+      </div>
+    </main>
+  );
+}

--- a/src/components/claims/ClaimsClient.tsx
+++ b/src/components/claims/ClaimsClient.tsx
@@ -232,6 +232,7 @@ function ClaimCard({
 
   return (
     <div
+      id={`claim-${claim.id}`}
       className={`panel ${compact ? "py-3 px-4" : "py-4 px-5"}`}
       style={{
         borderLeft: "var(--border-rule) solid var(--color-accent-ink)",

--- a/src/components/entities/EntitiesClient.tsx
+++ b/src/components/entities/EntitiesClient.tsx
@@ -147,6 +147,7 @@ export function EntitiesClient({
             {entities.map((entity) => (
               <div
                 key={entity.id}
+                id={`entity-row-${entity.id}`}
                 className="panel-raised"
                 style={{ padding: "1rem 1.125rem" }}
               >

--- a/src/components/search/GlobalSearchBar.tsx
+++ b/src/components/search/GlobalSearchBar.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+
+interface GlobalSearchBarProps {
+  dossierId?: string;
+  initialQuery?: string;
+  placeholder?: string;
+}
+
+export function GlobalSearchBar({
+  dossierId,
+  initialQuery = "",
+  placeholder,
+}: GlobalSearchBarProps) {
+  const router = useRouter();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [value, setValue] = useState(initialQuery);
+
+  useEffect(() => {
+    setValue(initialQuery);
+  }, [initialQuery]);
+
+  // Keyboard shortcut: ⌘/Ctrl-K focuses the bar.
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    const query = value.trim();
+    if (!query) return;
+
+    const params = new URLSearchParams({ q: query });
+    if (dossierId) {
+      params.set("dossierId", dossierId);
+    }
+    router.push(`/search?${params.toString()}`);
+  }
+
+  const resolvedPlaceholder =
+    placeholder ??
+    (dossierId
+      ? "Search this dossier…"
+      : "Search dossiers, sources, claims…");
+
+  return (
+    <form
+      role="search"
+      onSubmit={handleSubmit}
+      className="flex items-center w-full"
+      style={{ maxWidth: "32rem" }}
+    >
+      <div
+        className="flex items-center w-full"
+        style={{
+          border: "var(--border-thin) solid var(--color-border)",
+          borderRadius: "var(--radius-sm)",
+          backgroundColor: "var(--color-bg-panel)",
+          paddingInline: "0.625rem",
+          gap: "0.5rem",
+        }}
+      >
+        <span
+          aria-hidden
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.75rem",
+            color: "var(--color-ink-secondary)",
+            letterSpacing: "0.04em",
+          }}
+        >
+          ⌕
+        </span>
+        <input
+          ref={inputRef}
+          type="search"
+          name="q"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder={resolvedPlaceholder}
+          aria-label="Search"
+          autoComplete="off"
+          spellCheck={false}
+          style={{
+            flex: 1,
+            padding: "0.375rem 0",
+            fontFamily: "var(--font-sans)",
+            fontSize: "0.875rem",
+            color: "var(--color-ink-primary)",
+            background: "transparent",
+            border: "none",
+            outline: "none",
+          }}
+        />
+        <span
+          aria-hidden
+          className="hidden sm:inline"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.6875rem",
+            color: "var(--color-ink-secondary)",
+            border: "var(--border-hairline) solid var(--color-border)",
+            borderRadius: "var(--radius-xs)",
+            padding: "0.0625rem 0.3125rem",
+            backgroundColor: "var(--color-bg-selected)",
+          }}
+        >
+          ⌘K
+        </span>
+      </div>
+    </form>
+  );
+}

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -1,0 +1,215 @@
+import Link from "next/link";
+import type {
+  SearchObjectType,
+  SearchResultBase,
+  SearchResults as SearchResultsData,
+} from "@/server/queries/search";
+
+interface SearchResultsProps {
+  results: SearchResultsData;
+  dossierTitle: string | null;
+}
+
+const TYPE_LABELS: Record<SearchObjectType, string> = {
+  dossier: "Dossiers",
+  source: "Sources",
+  highlight: "Highlights",
+  claim: "Claims",
+  entity: "Entities",
+  brief: "Briefs",
+};
+
+const TYPE_ORDER: SearchObjectType[] = [
+  "dossier",
+  "source",
+  "highlight",
+  "claim",
+  "entity",
+  "brief",
+];
+
+export function SearchResults({ results, dossierTitle }: SearchResultsProps) {
+  if (!results.query) {
+    return (
+      <EmptyState
+        message="Enter a term to search across dossiers, sources, highlights, claims, entities, and briefs."
+      />
+    );
+  }
+
+  if (results.total === 0) {
+    return (
+      <EmptyState
+        message={
+          dossierTitle
+            ? `No matches for “${results.query}” in ${dossierTitle}.`
+            : `No matches for “${results.query}”.`
+        }
+      />
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1.75rem" }}>
+      {TYPE_ORDER.map((type) => {
+        const items = results.groups[type];
+        if (!items || items.length === 0) return null;
+        return <ResultGroup key={type} type={type} items={items} />;
+      })}
+    </div>
+  );
+}
+
+function ResultGroup({
+  type,
+  items,
+}: {
+  type: SearchObjectType;
+  items: SearchResultBase[];
+}) {
+  return (
+    <section>
+      <header
+        className="flex items-baseline justify-between"
+        style={{ marginBottom: "0.625rem" }}
+      >
+        <h2
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.6875rem",
+            textTransform: "uppercase",
+            letterSpacing: "0.1em",
+            color: "var(--color-ink-secondary)",
+            fontWeight: 500,
+          }}
+        >
+          {TYPE_LABELS[type]}
+        </h2>
+        <span
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.6875rem",
+            color: "var(--color-ink-secondary)",
+          }}
+        >
+          {items.length} result{items.length === 1 ? "" : "s"}
+        </span>
+      </header>
+
+      <div className="panel" style={{ overflow: "hidden" }}>
+        {items.map((item, i) => (
+          <Link
+            key={`${item.type}-${item.id}`}
+            href={item.href}
+            className="dossier-row-link"
+            style={{
+              display: "block",
+              padding: "0.75rem 1rem",
+              textDecoration: "none",
+              borderBottom:
+                i < items.length - 1
+                  ? "var(--border-hairline) solid var(--color-border)"
+                  : undefined,
+            }}
+          >
+            <div
+              className="flex items-baseline justify-between"
+              style={{ gap: "1rem", marginBottom: "0.25rem" }}
+            >
+              <p
+                className="overflow-hidden text-ellipsis whitespace-nowrap"
+                style={{
+                  fontFamily:
+                    item.type === "highlight"
+                      ? "var(--font-display)"
+                      : "var(--font-sans)",
+                  fontStyle: item.type === "highlight" ? "italic" : "normal",
+                  fontSize: "0.9375rem",
+                  fontWeight: 500,
+                  color: "var(--color-ink-primary)",
+                  minWidth: 0,
+                  flex: 1,
+                }}
+              >
+                {item.type === "highlight"
+                  ? `“${item.title}”`
+                  : item.title}
+              </p>
+              <span
+                className="shrink-0"
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "0.6875rem",
+                  color: "var(--color-ink-secondary)",
+                }}
+              >
+                {item.dossierTitle}
+              </span>
+            </div>
+            {item.snippet && (
+              <p
+                style={{
+                  fontFamily: "var(--font-sans)",
+                  fontSize: "0.8125rem",
+                  color: "var(--color-ink-secondary)",
+                  margin: 0,
+                  maxWidth: "none",
+                  display: "-webkit-box",
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: "vertical",
+                  overflow: "hidden",
+                }}
+              >
+                {renderSnippet(item.snippet)}
+              </p>
+            )}
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div
+      className="panel"
+      style={{ padding: "2.5rem 2rem", textAlign: "center" }}
+    >
+      <p
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: "0.8125rem",
+          color: "var(--color-ink-secondary)",
+        }}
+      >
+        {message}
+      </p>
+    </div>
+  );
+}
+
+// ts_headline wraps matches in `<<…>>` — split the string so we can render
+// matched fragments with an inline highlight without dangerouslySetInnerHTML.
+function renderSnippet(snippet: string): React.ReactNode {
+  const parts = snippet.split(/(<<[^>]*>>)/g);
+  return parts.map((part, i) => {
+    const match = part.match(/^<<(.*)>>$/);
+    if (match) {
+      return (
+        <mark
+          key={i}
+          style={{
+            backgroundColor: "var(--color-highlight-wash)",
+            color: "var(--color-ink-primary)",
+            padding: "0 0.125rem",
+            borderRadius: "var(--radius-xs)",
+          }}
+        >
+          {match[1]}
+        </mark>
+      );
+    }
+    return <span key={i}>{part}</span>;
+  });
+}

--- a/src/components/sources/SourceReaderClient.tsx
+++ b/src/components/sources/SourceReaderClient.tsx
@@ -606,6 +606,7 @@ export function SourceReaderClient({
                 return (
                   <div
                     key={h.id}
+                    id={`highlight-${h.id}`}
                     style={{
                       padding: "0.5rem",
                       borderLeft:

--- a/src/server/queries/__tests__/search.test.ts
+++ b/src/server/queries/__tests__/search.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockQueryRaw } = vi.hoisted(() => ({
+  mockQueryRaw: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: { $queryRaw: mockQueryRaw },
+}));
+
+import {
+  SEARCH_OBJECT_TYPES,
+  searchWorkspace,
+} from "../search";
+
+describe("searchWorkspace", () => {
+  beforeEach(() => {
+    mockQueryRaw.mockReset();
+  });
+
+  it("returns an empty grouped result set for a blank query without hitting the db", async () => {
+    const result = await searchWorkspace("user-1", "   ");
+
+    expect(result.total).toBe(0);
+    expect(result.query).toBe("");
+    expect(mockQueryRaw).not.toHaveBeenCalled();
+    for (const type of SEARCH_OBJECT_TYPES) {
+      expect(result.groups[type]).toEqual([]);
+    }
+  });
+
+  it("runs one raw query per requested type and groups results by object type", async () => {
+    // Return one synthetic row per type so we can confirm grouping.
+    mockQueryRaw
+      .mockResolvedValueOnce([
+        {
+          id: "dos-1",
+          title: "Dossier One",
+          snippet: "<<alpha>> summary",
+          dossier_id: "dos-1",
+          dossier_title: "Dossier One",
+          rank: 0.5,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: "src-1",
+          title: "Source One",
+          snippet: null,
+          dossier_id: "dos-1",
+          dossier_title: "Dossier One",
+          rank: 0.4,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: "hl-1",
+          title: "Highlighted quote",
+          snippet: null,
+          dossier_id: "dos-1",
+          dossier_title: "Dossier One",
+          source_id: "src-1",
+          rank: 0.3,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: "clm-1",
+          title: "A claim",
+          snippet: null,
+          dossier_id: "dos-1",
+          dossier_title: "Dossier One",
+          rank: 0.2,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: "ent-1",
+          title: "Acme Corp",
+          snippet: null,
+          dossier_id: "dos-1",
+          dossier_title: "Dossier One",
+          rank: 0.1,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: "brf-1",
+          title: "Brief One",
+          snippet: null,
+          dossier_id: "dos-1",
+          dossier_title: "Dossier One",
+          rank: 0.05,
+        },
+      ]);
+
+    const result = await searchWorkspace("user-1", "alpha");
+
+    expect(mockQueryRaw).toHaveBeenCalledTimes(SEARCH_OBJECT_TYPES.length);
+    expect(result.total).toBe(SEARCH_OBJECT_TYPES.length);
+    expect(result.groups.dossier[0]).toMatchObject({
+      id: "dos-1",
+      type: "dossier",
+      href: "/dossiers/dos-1/overview",
+    });
+    expect(result.groups.source[0]).toMatchObject({
+      type: "source",
+      href: "/dossiers/dos-1/sources/src-1",
+    });
+    expect(result.groups.highlight[0]).toMatchObject({
+      type: "highlight",
+      href: "/dossiers/dos-1/sources/src-1#highlight-hl-1",
+    });
+    expect(result.groups.claim[0]).toMatchObject({
+      type: "claim",
+      href: "/dossiers/dos-1/claims#claim-clm-1",
+    });
+    expect(result.groups.entity[0]).toMatchObject({
+      type: "entity",
+      href: "/dossiers/dos-1/entities#entity-ent-1",
+    });
+    expect(result.groups.brief[0]).toMatchObject({
+      type: "brief",
+      href: "/dossiers/dos-1/brief",
+    });
+  });
+
+  it("honors an explicit object-type filter and only runs those queries", async () => {
+    mockQueryRaw.mockResolvedValue([]);
+
+    const result = await searchWorkspace("user-1", "alpha", {
+      types: ["claim", "entity"],
+    });
+
+    expect(mockQueryRaw).toHaveBeenCalledTimes(2);
+    expect(result.types).toEqual(["claim", "entity"]);
+  });
+
+  it("passes the dossier scope into every raw query", async () => {
+    mockQueryRaw.mockResolvedValue([]);
+
+    await searchWorkspace("user-1", "alpha", { dossierId: "dos-9" });
+
+    expect(mockQueryRaw).toHaveBeenCalledTimes(SEARCH_OBJECT_TYPES.length);
+    // Each call receives a Prisma.sql tagged template — we just ensure the
+    // dossier id is present in the interpolated values for every call.
+    for (const call of mockQueryRaw.mock.calls) {
+      const serialized = JSON.stringify(call);
+      expect(serialized).toContain("dos-9");
+    }
+  });
+
+  it("cleans up whitespace in snippets returned from ts_headline", async () => {
+    mockQueryRaw
+      .mockResolvedValueOnce([
+        {
+          id: "dos-1",
+          title: "Dossier One",
+          snippet: "  lots   of\n\n whitespace  ",
+          dossier_id: "dos-1",
+          dossier_title: "Dossier One",
+          rank: 0.5,
+        },
+      ])
+      .mockResolvedValue([]);
+
+    const result = await searchWorkspace("user-1", "alpha", {
+      types: ["dossier"],
+    });
+
+    expect(result.groups.dossier[0].snippet).toBe("lots of whitespace");
+  });
+
+  it("truncates very long claim statements used as titles", async () => {
+    const longStatement = "x".repeat(200);
+    mockQueryRaw.mockResolvedValueOnce([
+      {
+        id: "clm-1",
+        title: longStatement,
+        snippet: null,
+        dossier_id: "dos-1",
+        dossier_title: "Dossier One",
+        rank: 0.1,
+      },
+    ]);
+
+    const result = await searchWorkspace("user-1", "alpha", {
+      types: ["claim"],
+    });
+
+    expect(result.groups.claim[0].title.length).toBeLessThan(longStatement.length);
+    expect(result.groups.claim[0].title.endsWith("…")).toBe(true);
+  });
+});

--- a/src/server/queries/__tests__/search.test.ts
+++ b/src/server/queries/__tests__/search.test.ts
@@ -117,7 +117,7 @@ describe("searchWorkspace", () => {
     });
     expect(result.groups.entity[0]).toMatchObject({
       type: "entity",
-      href: "/dossiers/dos-1/entities#entity-ent-1",
+      href: "/dossiers/dos-1/entities#entity-row-ent-1",
     });
     expect(result.groups.brief[0]).toMatchObject({
       type: "brief",

--- a/src/server/queries/search.ts
+++ b/src/server/queries/search.ts
@@ -1,0 +1,470 @@
+import { Prisma } from "@prisma/client";
+import { db } from "@/lib/db";
+
+export const SEARCH_OBJECT_TYPES = [
+  "dossier",
+  "source",
+  "highlight",
+  "claim",
+  "entity",
+  "brief",
+] as const;
+
+export type SearchObjectType = (typeof SEARCH_OBJECT_TYPES)[number];
+
+export interface SearchResultBase {
+  id: string;
+  type: SearchObjectType;
+  title: string;
+  snippet: string | null;
+  dossierId: string;
+  dossierTitle: string;
+  href: string;
+  rank: number;
+}
+
+export interface SearchResults {
+  query: string;
+  dossierId: string | null;
+  types: SearchObjectType[];
+  groups: Record<SearchObjectType, SearchResultBase[]>;
+  total: number;
+}
+
+export interface SearchOptions {
+  dossierId?: string | null;
+  types?: SearchObjectType[];
+  perTypeLimit?: number;
+}
+
+const DEFAULT_PER_TYPE_LIMIT = 8;
+
+type RawRow = {
+  id: string;
+  title: string;
+  snippet: string | null;
+  dossier_id: string;
+  dossier_title: string;
+  rank: number;
+};
+
+type RawHighlightRow = RawRow & { source_id: string };
+
+function emptyGroups(): Record<SearchObjectType, SearchResultBase[]> {
+  return SEARCH_OBJECT_TYPES.reduce(
+    (acc, type) => {
+      acc[type] = [];
+      return acc;
+    },
+    {} as Record<SearchObjectType, SearchResultBase[]>,
+  );
+}
+
+export async function searchWorkspace(
+  userId: string,
+  rawQuery: string,
+  options: SearchOptions = {},
+): Promise<SearchResults> {
+  const query = rawQuery.trim();
+  const groups = emptyGroups();
+
+  const requestedTypes =
+    options.types && options.types.length > 0
+      ? options.types
+      : [...SEARCH_OBJECT_TYPES];
+
+  const empty: SearchResults = {
+    query,
+    dossierId: options.dossierId ?? null,
+    types: requestedTypes,
+    groups,
+    total: 0,
+  };
+
+  if (query.length === 0) return empty;
+
+  const limit = Math.max(1, Math.min(50, options.perTypeLimit ?? DEFAULT_PER_TYPE_LIMIT));
+  const dossierFilter = options.dossierId ?? null;
+
+  const tasks = requestedTypes.map((type) =>
+    runSearch(type, userId, query, dossierFilter, limit).then((rows) => {
+      groups[type] = rows;
+    }),
+  );
+  await Promise.all(tasks);
+
+  const total = SEARCH_OBJECT_TYPES.reduce(
+    (sum, type) => sum + groups[type].length,
+    0,
+  );
+
+  return {
+    query,
+    dossierId: dossierFilter,
+    types: requestedTypes,
+    groups,
+    total,
+  };
+}
+
+async function runSearch(
+  type: SearchObjectType,
+  userId: string,
+  query: string,
+  dossierId: string | null,
+  limit: number,
+): Promise<SearchResultBase[]> {
+  switch (type) {
+    case "dossier":
+      return searchDossiers(userId, query, dossierId, limit);
+    case "source":
+      return searchSources(userId, query, dossierId, limit);
+    case "highlight":
+      return searchHighlights(userId, query, dossierId, limit);
+    case "claim":
+      return searchClaims(userId, query, dossierId, limit);
+    case "entity":
+      return searchEntities(userId, query, dossierId, limit);
+    case "brief":
+      return searchBriefs(userId, query, dossierId, limit);
+  }
+}
+
+// ─── Per-type search helpers ─────────────────────────────────────────────────
+//
+// All queries share the same shape: build a `plainto_tsquery('simple', ...)`
+// from the user input, filter by ownership (and optionally dossier), rank by
+// `ts_rank`, and extract an HTML-free snippet with `ts_headline`.
+//
+// `plainto_tsquery` is used rather than `to_tsquery` so untrusted user input
+// is parsed safely and never interpreted as query operators.
+
+async function searchDossiers(
+  userId: string,
+  query: string,
+  dossierId: string | null,
+  limit: number,
+): Promise<SearchResultBase[]> {
+  const rows = await db.$queryRaw<RawRow[]>`
+    SELECT
+      d.id,
+      d.title,
+      d.id AS dossier_id,
+      d.title AS dossier_title,
+      ts_headline(
+        'simple',
+        coalesce(d.summary, '') || ' ' || coalesce(d.research_goal, ''),
+        plainto_tsquery('simple', ${query}),
+        'StartSel=<<,StopSel=>>,MaxWords=24,MinWords=8,ShortWord=3,MaxFragments=1'
+      ) AS snippet,
+      ts_rank(
+        to_tsvector(
+          'simple',
+          coalesce(d.title, '') || ' ' ||
+          coalesce(d.summary, '') || ' ' ||
+          coalesce(d.research_goal, '')
+        ),
+        plainto_tsquery('simple', ${query})
+      ) AS rank
+    FROM dossiers d
+    WHERE d.owner_id = ${userId}
+      ${dossierId ? Prisma.sql`AND d.id = ${dossierId}` : Prisma.empty}
+      AND to_tsvector(
+        'simple',
+        coalesce(d.title, '') || ' ' ||
+        coalesce(d.summary, '') || ' ' ||
+        coalesce(d.research_goal, '')
+      ) @@ plainto_tsquery('simple', ${query})
+    ORDER BY rank DESC, d.updated_at DESC
+    LIMIT ${limit}
+  `;
+
+  return rows.map((row) => ({
+    id: row.id,
+    type: "dossier",
+    title: row.title,
+    snippet: cleanSnippet(row.snippet),
+    dossierId: row.dossier_id,
+    dossierTitle: row.dossier_title,
+    href: `/dossiers/${row.id}/overview`,
+    rank: Number(row.rank),
+  }));
+}
+
+async function searchSources(
+  userId: string,
+  query: string,
+  dossierId: string | null,
+  limit: number,
+): Promise<SearchResultBase[]> {
+  const rows = await db.$queryRaw<RawRow[]>`
+    SELECT
+      s.id,
+      s.title,
+      s.dossier_id,
+      d.title AS dossier_title,
+      ts_headline(
+        'simple',
+        coalesce(s.summary, '') || ' ' || coalesce(s.raw_text, ''),
+        plainto_tsquery('simple', ${query}),
+        'StartSel=<<,StopSel=>>,MaxWords=24,MinWords=8,ShortWord=3,MaxFragments=1'
+      ) AS snippet,
+      ts_rank(
+        to_tsvector(
+          'simple',
+          coalesce(s.title, '') || ' ' ||
+          coalesce(s.author, '') || ' ' ||
+          coalesce(s.publisher, '') || ' ' ||
+          coalesce(s.summary, '') || ' ' ||
+          coalesce(s.raw_text, '')
+        ),
+        plainto_tsquery('simple', ${query})
+      ) AS rank
+    FROM sources s
+    JOIN dossiers d ON d.id = s.dossier_id
+    WHERE d.owner_id = ${userId}
+      ${dossierId ? Prisma.sql`AND s.dossier_id = ${dossierId}` : Prisma.empty}
+      AND to_tsvector(
+        'simple',
+        coalesce(s.title, '') || ' ' ||
+        coalesce(s.author, '') || ' ' ||
+        coalesce(s.publisher, '') || ' ' ||
+        coalesce(s.summary, '') || ' ' ||
+        coalesce(s.raw_text, '')
+      ) @@ plainto_tsquery('simple', ${query})
+    ORDER BY rank DESC, s.captured_at DESC
+    LIMIT ${limit}
+  `;
+
+  return rows.map((row) => ({
+    id: row.id,
+    type: "source",
+    title: row.title,
+    snippet: cleanSnippet(row.snippet),
+    dossierId: row.dossier_id,
+    dossierTitle: row.dossier_title,
+    href: `/dossiers/${row.dossier_id}/sources/${row.id}`,
+    rank: Number(row.rank),
+  }));
+}
+
+async function searchHighlights(
+  userId: string,
+  query: string,
+  dossierId: string | null,
+  limit: number,
+): Promise<SearchResultBase[]> {
+  const rows = await db.$queryRaw<RawHighlightRow[]>`
+    SELECT
+      h.id,
+      h.quote_text AS title,
+      s.id AS source_id,
+      s.dossier_id,
+      d.title AS dossier_title,
+      ts_headline(
+        'simple',
+        coalesce(h.quote_text, '') || ' ' || coalesce(h.annotation, ''),
+        plainto_tsquery('simple', ${query}),
+        'StartSel=<<,StopSel=>>,MaxWords=24,MinWords=8,ShortWord=3,MaxFragments=1'
+      ) AS snippet,
+      ts_rank(
+        to_tsvector(
+          'simple',
+          coalesce(h.quote_text, '') || ' ' ||
+          coalesce(h.annotation, '')
+        ),
+        plainto_tsquery('simple', ${query})
+      ) AS rank
+    FROM highlights h
+    JOIN sources s ON s.id = h.source_id
+    JOIN dossiers d ON d.id = s.dossier_id
+    WHERE d.owner_id = ${userId}
+      ${dossierId ? Prisma.sql`AND s.dossier_id = ${dossierId}` : Prisma.empty}
+      AND to_tsvector(
+        'simple',
+        coalesce(h.quote_text, '') || ' ' ||
+        coalesce(h.annotation, '')
+      ) @@ plainto_tsquery('simple', ${query})
+    ORDER BY rank DESC, h.created_at DESC
+    LIMIT ${limit}
+  `;
+
+  return rows.map((row) => ({
+    id: row.id,
+    type: "highlight",
+    title: truncate(row.title, 80),
+    snippet: cleanSnippet(row.snippet),
+    dossierId: row.dossier_id,
+    dossierTitle: row.dossier_title,
+    href: `/dossiers/${row.dossier_id}/sources/${row.source_id}#highlight-${row.id}`,
+    rank: Number(row.rank),
+  }));
+}
+
+async function searchClaims(
+  userId: string,
+  query: string,
+  dossierId: string | null,
+  limit: number,
+): Promise<SearchResultBase[]> {
+  const rows = await db.$queryRaw<RawRow[]>`
+    SELECT
+      c.id,
+      c.statement AS title,
+      c.dossier_id,
+      d.title AS dossier_title,
+      ts_headline(
+        'simple',
+        coalesce(c.statement, '') || ' ' || coalesce(c.notes, ''),
+        plainto_tsquery('simple', ${query}),
+        'StartSel=<<,StopSel=>>,MaxWords=24,MinWords=8,ShortWord=3,MaxFragments=1'
+      ) AS snippet,
+      ts_rank(
+        to_tsvector(
+          'simple',
+          coalesce(c.statement, '') || ' ' ||
+          coalesce(c.notes, '')
+        ),
+        plainto_tsquery('simple', ${query})
+      ) AS rank
+    FROM claims c
+    JOIN dossiers d ON d.id = c.dossier_id
+    WHERE d.owner_id = ${userId}
+      ${dossierId ? Prisma.sql`AND c.dossier_id = ${dossierId}` : Prisma.empty}
+      AND to_tsvector(
+        'simple',
+        coalesce(c.statement, '') || ' ' ||
+        coalesce(c.notes, '')
+      ) @@ plainto_tsquery('simple', ${query})
+    ORDER BY rank DESC, c.updated_at DESC
+    LIMIT ${limit}
+  `;
+
+  return rows.map((row) => ({
+    id: row.id,
+    type: "claim",
+    title: truncate(row.title, 120),
+    snippet: cleanSnippet(row.snippet),
+    dossierId: row.dossier_id,
+    dossierTitle: row.dossier_title,
+    href: `/dossiers/${row.dossier_id}/claims#claim-${row.id}`,
+    rank: Number(row.rank),
+  }));
+}
+
+async function searchEntities(
+  userId: string,
+  query: string,
+  dossierId: string | null,
+  limit: number,
+): Promise<SearchResultBase[]> {
+  const rows = await db.$queryRaw<RawRow[]>`
+    SELECT
+      e.id,
+      e.name AS title,
+      e.dossier_id,
+      d.title AS dossier_title,
+      ts_headline(
+        'simple',
+        coalesce(e.description, '') || ' ' || array_to_string(e.aliases, ' '),
+        plainto_tsquery('simple', ${query}),
+        'StartSel=<<,StopSel=>>,MaxWords=24,MinWords=8,ShortWord=3,MaxFragments=1'
+      ) AS snippet,
+      ts_rank(
+        to_tsvector(
+          'simple',
+          coalesce(e.name, '') || ' ' ||
+          coalesce(e.description, '') || ' ' ||
+          array_to_string(e.aliases, ' ')
+        ),
+        plainto_tsquery('simple', ${query})
+      ) AS rank
+    FROM entities e
+    JOIN dossiers d ON d.id = e.dossier_id
+    WHERE d.owner_id = ${userId}
+      ${dossierId ? Prisma.sql`AND e.dossier_id = ${dossierId}` : Prisma.empty}
+      AND to_tsvector(
+        'simple',
+        coalesce(e.name, '') || ' ' ||
+        coalesce(e.description, '') || ' ' ||
+        array_to_string(e.aliases, ' ')
+      ) @@ plainto_tsquery('simple', ${query})
+    ORDER BY rank DESC, e.updated_at DESC
+    LIMIT ${limit}
+  `;
+
+  return rows.map((row) => ({
+    id: row.id,
+    type: "entity",
+    title: row.title,
+    snippet: cleanSnippet(row.snippet),
+    dossierId: row.dossier_id,
+    dossierTitle: row.dossier_title,
+    href: `/dossiers/${row.dossier_id}/entities#entity-${row.id}`,
+    rank: Number(row.rank),
+  }));
+}
+
+async function searchBriefs(
+  userId: string,
+  query: string,
+  dossierId: string | null,
+  limit: number,
+): Promise<SearchResultBase[]> {
+  const rows = await db.$queryRaw<RawRow[]>`
+    SELECT
+      b.id,
+      b.title,
+      b.dossier_id,
+      d.title AS dossier_title,
+      ts_headline(
+        'simple',
+        coalesce(b.body_markdown, ''),
+        plainto_tsquery('simple', ${query}),
+        'StartSel=<<,StopSel=>>,MaxWords=24,MinWords=8,ShortWord=3,MaxFragments=1'
+      ) AS snippet,
+      ts_rank(
+        to_tsvector(
+          'simple',
+          coalesce(b.title, '') || ' ' ||
+          coalesce(b.body_markdown, '')
+        ),
+        plainto_tsquery('simple', ${query})
+      ) AS rank
+    FROM briefs b
+    JOIN dossiers d ON d.id = b.dossier_id
+    WHERE d.owner_id = ${userId}
+      ${dossierId ? Prisma.sql`AND b.dossier_id = ${dossierId}` : Prisma.empty}
+      AND to_tsvector(
+        'simple',
+        coalesce(b.title, '') || ' ' ||
+        coalesce(b.body_markdown, '')
+      ) @@ plainto_tsquery('simple', ${query})
+    ORDER BY rank DESC, b.updated_at DESC
+    LIMIT ${limit}
+  `;
+
+  return rows.map((row) => ({
+    id: row.id,
+    type: "brief",
+    title: row.title,
+    snippet: cleanSnippet(row.snippet),
+    dossierId: row.dossier_id,
+    dossierTitle: row.dossier_title,
+    href: `/dossiers/${row.dossier_id}/brief`,
+    rank: Number(row.rank),
+  }));
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function cleanSnippet(raw: string | null): string | null {
+  if (!raw) return null;
+  const trimmed = raw.replace(/\s+/g, " ").trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 1).trimEnd()}…`;
+}

--- a/src/server/queries/search.ts
+++ b/src/server/queries/search.ts
@@ -400,7 +400,7 @@ async function searchEntities(
     snippet: cleanSnippet(row.snippet),
     dossierId: row.dossier_id,
     dossierTitle: row.dossier_title,
-    href: `/dossiers/${row.dossier_id}/entities#entity-${row.id}`,
+    href: `/dossiers/${row.dossier_id}/entities#entity-row-${row.id}`,
     rank: Number(row.rank),
   }));
 }


### PR DESCRIPTION
## Summary

- Add PostgreSQL full-text search across dossiers, sources, highlights, claims, entities, and events via a new migration that provisions `tsvector` columns, GIN indexes, and triggers to keep them in sync
- Implement `/api/search` route and server query layer (`src/server/queries/search.ts`) that runs scoped, user-filtered ranked queries across all six object types with snippet extraction
- Add a dedicated `/search` results page and a `GlobalSearchBar` component wired into the dossiers list and dossier detail layouts for app-wide access
- Render grouped, typed results with highlighted snippets and deep links to the originating object via `SearchResults`
- Cover the new query layer and API route with unit tests (`search.test.ts` in both `server/queries/__tests__` and `app/api/search`)

Closes #23

## Validation

- [x] Code builds successfully
- [x] Lint passes
- [x] Typecheck passes
- [ ] Tests pass (if applicable)
- [ ] Matches design direction from product spec
