### PR TITLE
feat(DOS-024): Build Markdown and PDF export

### DIFF
--- a/src/app/api/dossiers/[id]/brief/export/route.ts
+++ b/src/app/api/dossiers/[id]/brief/export/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import {
+  buildExportFilename,
+  renderBriefMarkdown,
+} from "@/lib/briefExport";
+import { getBriefEvidence, getOrCreateBrief } from "@/server/queries/briefs";
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(_req: Request, context: RouteContext) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await context.params;
+
+  let brief, evidence;
+  try {
+    [brief, evidence] = await Promise.all([
+      getOrCreateBrief(id, session.user.id),
+      getBriefEvidence(id, session.user.id),
+    ]);
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to load brief. Please try again." },
+      { status: 500 },
+    );
+  }
+
+  if (!brief) {
+    return NextResponse.json({ error: "Brief not found." }, { status: 404 });
+  }
+
+  const markdown = renderBriefMarkdown(
+    { title: brief.title, body_markdown: brief.body_markdown },
+    evidence,
+  );
+  const filename = buildExportFilename(brief.title, "md");
+
+  return new NextResponse(markdown, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/src/app/briefs/[dossierId]/print/page.tsx
+++ b/src/app/briefs/[dossierId]/print/page.tsx
@@ -1,0 +1,107 @@
+import type { Metadata } from "next";
+import { notFound, redirect } from "next/navigation";
+import { auth } from "@/auth";
+import {
+  formatSourceAttribution,
+  renderBriefBlocks,
+  renderBriefCitedSources,
+  type ExportSource,
+  type RenderedBodyBlock,
+  type RenderedInline,
+} from "@/lib/briefExport";
+import { getBriefEvidence, getOrCreateBrief } from "@/server/queries/briefs";
+import { BriefPrintLauncher } from "@/components/briefs/BriefPrintLauncher";
+import "./print.css";
+
+export const metadata: Metadata = {
+  title: "Brief — Print",
+  robots: { index: false, follow: false },
+};
+
+interface PrintPageProps {
+  params: Promise<{ dossierId: string }>;
+}
+
+export default async function BriefPrintPage({ params }: PrintPageProps) {
+  const session = await auth();
+  if (!session?.user?.id) redirect("/login");
+
+  const { dossierId } = await params;
+  const [brief, evidence] = await Promise.all([
+    getOrCreateBrief(dossierId, session.user.id),
+    getBriefEvidence(dossierId, session.user.id),
+  ]);
+
+  if (!brief) notFound();
+
+  const body = brief.body_markdown ?? "";
+  const blocks = renderBriefBlocks(body, evidence);
+  const citedSources: ExportSource[] = renderBriefCitedSources(body, evidence);
+  const title = brief.title.trim() || "Untitled brief";
+
+  return (
+    <>
+      <BriefPrintLauncher />
+      <div className="brief-print-root">
+        <article className="brief-print-article">
+          <header className="brief-print-header">
+            <span className="brief-print-eyebrow">Dossier · Brief</span>
+            <h1 className="brief-print-title">{title}</h1>
+          </header>
+
+          <div className="brief-print-body">
+            {blocks.length === 0 ? (
+              <p className="brief-print-empty">This brief is empty.</p>
+            ) : (
+              blocks.map((block, index) => renderBlock(block, index))
+            )}
+          </div>
+
+          {citedSources.length > 0 ? (
+            <section className="brief-print-sources">
+              <h2 className="brief-print-sources-heading">Sources</h2>
+              <ol className="brief-print-sources-list">
+                {citedSources.map((source) => (
+                  <li key={source.id}>{formatSourceAttribution(source)}</li>
+                ))}
+              </ol>
+            </section>
+          ) : null}
+        </article>
+      </div>
+    </>
+  );
+}
+
+function renderBlock(block: RenderedBodyBlock, index: number) {
+  if (block.type === "heading") {
+    const depth = Math.min(Math.max(block.depth ?? 2, 2), 6);
+    const Tag = (`h${depth}` as unknown) as keyof React.JSX.IntrinsicElements;
+    return (
+      <Tag key={index} className={`brief-print-heading brief-print-h${depth}`}>
+        {block.nodes.map((node, i) => renderInline(node, i))}
+      </Tag>
+    );
+  }
+  return (
+    <p key={index} className="brief-print-paragraph">
+      {block.nodes.map((node, i) => renderInline(node, i))}
+    </p>
+  );
+}
+
+function renderInline(node: RenderedInline, key: number) {
+  if (node.type === "text") return <span key={key}>{node.text}</span>;
+  return (
+    <span
+      key={key}
+      className={
+        node.resolved
+          ? "brief-print-citation"
+          : "brief-print-citation brief-print-citation-missing"
+      }
+    >
+      {node.text}
+    </span>
+  );
+}

--- a/src/app/briefs/[dossierId]/print/print.css
+++ b/src/app/briefs/[dossierId]/print/print.css
@@ -1,0 +1,168 @@
+.brief-print-root {
+  min-height: 100dvh;
+  background-color: var(--color-bg-canvas);
+  padding: 3rem 1.5rem 4rem;
+  display: flex;
+  justify-content: center;
+}
+
+.brief-print-article {
+  width: 100%;
+  max-width: 44rem;
+  background-color: var(--color-bg-panel);
+  border: var(--border-thin) solid var(--color-border);
+  box-shadow: var(--shadow-panel);
+  padding: 3rem 2.75rem 3.5rem;
+}
+
+.brief-print-header {
+  margin-bottom: 2rem;
+  padding-bottom: 1.25rem;
+  border-bottom: var(--border-thin) solid var(--color-border);
+}
+
+.brief-print-eyebrow {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-ink-secondary);
+  margin-bottom: 0.5rem;
+}
+
+.brief-print-title {
+  font-family: var(--font-display);
+  font-size: 2.125rem;
+  font-weight: 600;
+  line-height: 1.15;
+  color: var(--color-ink-primary);
+  letter-spacing: -0.015em;
+  margin: 0;
+}
+
+.brief-print-body {
+  font-family: var(--font-sans);
+  font-size: 1rem;
+  line-height: 1.75;
+  color: var(--color-ink-primary);
+}
+
+.brief-print-paragraph {
+  margin: 0 0 1.1rem;
+  color: var(--color-ink-primary);
+  max-width: none;
+}
+
+.brief-print-heading {
+  font-family: var(--font-display);
+  color: var(--color-ink-primary);
+  letter-spacing: -0.01em;
+  margin: 1.75rem 0 0.5rem;
+}
+
+.brief-print-h2 { font-size: 1.4rem; }
+.brief-print-h3 { font-size: 1.175rem; }
+.brief-print-h4 { font-size: 1.05rem; }
+.brief-print-h5 { font-size: 0.9375rem; }
+.brief-print-h6 { font-size: 0.875rem; }
+
+.brief-print-citation {
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  color: var(--color-accent-ink);
+  white-space: nowrap;
+}
+
+.brief-print-citation-missing {
+  color: var(--color-accent-alert);
+  font-style: italic;
+}
+
+.brief-print-empty {
+  font-style: italic;
+  color: var(--color-ink-secondary);
+}
+
+.brief-print-sources {
+  margin-top: 2.5rem;
+  padding-top: 1.25rem;
+  border-top: var(--border-thin) solid var(--color-border);
+}
+
+.brief-print-sources-heading {
+  font-family: var(--font-display);
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--color-ink-primary);
+  margin: 0 0 0.75rem;
+}
+
+.brief-print-sources-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  font-family: var(--font-sans);
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: var(--color-ink-primary);
+}
+
+.brief-print-sources-list li {
+  margin-bottom: 0.25rem;
+}
+
+@media print {
+  @page {
+    margin: 0.75in;
+  }
+
+  html,
+  body {
+    background: #ffffff !important;
+    background-image: none !important;
+    color: #111 !important;
+  }
+
+  .brief-print-root {
+    padding: 0;
+    background: transparent;
+    min-height: 0;
+    display: block;
+  }
+
+  .brief-print-article {
+    width: 100%;
+    max-width: none;
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    padding: 0;
+  }
+
+  .brief-print-header {
+    border-bottom: 1px solid #d4d0c6;
+    margin-bottom: 1.5rem;
+    padding-bottom: 0.75rem;
+  }
+
+  .brief-print-title {
+    font-size: 1.75rem;
+  }
+
+  .brief-print-heading,
+  .brief-print-title,
+  .brief-print-sources-heading {
+    break-after: avoid-page;
+    page-break-after: avoid;
+  }
+
+  .brief-print-paragraph {
+    orphans: 3;
+    widows: 3;
+  }
+
+  .brief-print-sources {
+    break-before: auto;
+    margin-top: 1.75rem;
+  }
+}

--- a/src/components/briefs/BriefEditorClient.tsx
+++ b/src/components/briefs/BriefEditorClient.tsx
@@ -21,6 +21,7 @@ import {
   type CitationRef,
 } from "@/lib/citations";
 import { CitationToken } from "./CitationToken";
+import { BriefExportMenu } from "./BriefExportMenu";
 
 interface BriefSnapshot {
   title: string;
@@ -451,6 +452,10 @@ export function BriefEditorClient({
                 </button>
               ))}
             </div>
+            <BriefExportMenu
+              dossierId={dossierId}
+              disabled={status === "saving" || status === "dirty"}
+            />
             <span
               role="status"
               aria-live="polite"

--- a/src/components/briefs/BriefExportMenu.tsx
+++ b/src/components/briefs/BriefExportMenu.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useState } from "react";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+
+interface Props {
+  dossierId: string;
+  disabled?: boolean;
+}
+
+export function BriefExportMenu({ dossierId, disabled }: Props) {
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleMarkdown() {
+    setError(null);
+    try {
+      const response = await fetch(
+        `/api/dossiers/${dossierId}/brief/export`,
+        { method: "GET" },
+      );
+      if (!response.ok) {
+        const message = await safeErrorMessage(response);
+        setError(message);
+        return;
+      }
+      const blob = await response.blob();
+      const filename = parseContentDispositionFilename(
+        response.headers.get("Content-Disposition"),
+      );
+      triggerDownload(blob, filename);
+    } catch {
+      setError("Markdown export failed. Please try again.");
+    }
+  }
+
+  function handlePdf() {
+    setError(null);
+    if (typeof window === "undefined") return;
+    // Opens a print-styled page that auto-triggers the browser's print
+    // dialog; users save as PDF from there.
+    const printed = window.open(
+      `/briefs/${dossierId}/print`,
+      "_blank",
+      "noopener",
+    );
+    if (!printed) {
+      setError("Enable pop-ups to export a PDF.");
+    }
+  }
+
+  return (
+    <div className="flex items-center" style={{ gap: "0.5rem" }}>
+      {error ? (
+        <span
+          role="alert"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.6875rem",
+            color: "var(--color-accent-alert)",
+          }}
+        >
+          {error}
+        </span>
+      ) : null}
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger asChild>
+          <button
+            type="button"
+            className="btn btn-secondary"
+            disabled={disabled}
+            aria-label="Export brief"
+            style={{
+              padding: "0.25rem 0.625rem",
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.6875rem",
+              textTransform: "uppercase",
+              letterSpacing: "0.08em",
+            }}
+          >
+            Export ▾
+          </button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content
+            align="end"
+            sideOffset={4}
+            style={{
+              minWidth: "180px",
+              backgroundColor: "var(--color-bg-panel)",
+              border: "var(--border-thin) solid var(--color-border)",
+              borderRadius: "var(--radius-md)",
+              boxShadow: "var(--shadow-float)",
+              padding: "0.25rem 0",
+              zIndex: 20,
+            }}
+          >
+            <DropdownMenu.Item
+              onSelect={() => {
+                void handleMarkdown();
+              }}
+              className="source-status-menu-item"
+              style={menuItemStyle}
+            >
+              Download Markdown (.md)
+            </DropdownMenu.Item>
+            <DropdownMenu.Item
+              onSelect={() => handlePdf()}
+              className="source-status-menu-item"
+              style={menuItemStyle}
+            >
+              Export as PDF…
+            </DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
+    </div>
+  );
+}
+
+const menuItemStyle: React.CSSProperties = {
+  display: "block",
+  width: "100%",
+  textAlign: "left",
+  padding: "0.375rem 0.75rem",
+  fontSize: "0.8125rem",
+  fontFamily: "var(--font-sans)",
+  color: "var(--color-ink-primary)",
+  background: "none",
+  border: "none",
+  cursor: "pointer",
+  outline: "none",
+  transition: "background-color var(--duration-fast)",
+};
+
+async function safeErrorMessage(response: Response): Promise<string> {
+  try {
+    const data = (await response.json()) as { error?: string };
+    return data.error ?? "Export failed. Please try again.";
+  } catch {
+    return "Export failed. Please try again.";
+  }
+}
+
+function parseContentDispositionFilename(header: string | null): string {
+  if (!header) return "brief.md";
+  const match = /filename\*?=(?:UTF-8'')?"?([^";]+)"?/i.exec(header);
+  return match?.[1] ?? "brief.md";
+}
+
+function triggerDownload(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}

--- a/src/components/briefs/BriefPrintLauncher.tsx
+++ b/src/components/briefs/BriefPrintLauncher.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Triggers the browser's print dialog once the print page has painted.
+ * Users pick "Save as PDF" to get a deliverable PDF without us shipping a
+ * heavyweight server-side renderer.
+ */
+export function BriefPrintLauncher() {
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      window.print();
+    }, 250);
+    return () => window.clearTimeout(timer);
+  }, []);
+  return null;
+}

--- a/src/lib/__tests__/briefExport.test.ts
+++ b/src/lib/__tests__/briefExport.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildExportFilename,
+  renderBriefBlocks,
+  renderBriefBodyPlain,
+  renderBriefCitedSources,
+  renderBriefMarkdown,
+  type ExportSource,
+} from "../briefExport";
+
+const sourceA: ExportSource = {
+  id: "srcA",
+  title: "Q3 Earnings Report",
+  author: "Jane Doe",
+  publisher: "Example Corp",
+  highlights: [
+    {
+      id: "h1",
+      source_id: "srcA",
+      page_number: 12,
+      start_offset: 0,
+      quote_text: "Revenue dropped 12% QoQ.",
+    },
+    {
+      id: "h2",
+      source_id: "srcA",
+      page_number: null,
+      start_offset: 1200,
+      quote_text: "Margins remained stable.",
+    },
+  ],
+};
+
+const sourceB: ExportSource = {
+  id: "srcB",
+  title: "Analyst Memo",
+  author: null,
+  publisher: null,
+  highlights: [],
+};
+
+const evidence = [sourceA, sourceB];
+
+describe("renderBriefBodyPlain", () => {
+  it("replaces highlight markers with '[Source, p.X]' style references", () => {
+    const body = "Revenue fell [[cite:highlight:h1]] this quarter.";
+    expect(renderBriefBodyPlain(body, evidence)).toBe(
+      "Revenue fell [Q3 Earnings Report, p.12] this quarter.",
+    );
+  });
+
+  it("uses paragraph anchor when highlight has no page number", () => {
+    const body = "A note: [[cite:highlight:h2]].";
+    expect(renderBriefBodyPlain(body, evidence)).toBe(
+      "A note: [Q3 Earnings Report, ¶4].",
+    );
+  });
+
+  it("replaces source markers with '[Source]' references", () => {
+    const body = "Per the analyst [[cite:source:srcB]], risk is low.";
+    expect(renderBriefBodyPlain(body, evidence)).toBe(
+      "Per the analyst [Analyst Memo], risk is low.",
+    );
+  });
+
+  it("emits '[missing citation]' when a reference can't be resolved", () => {
+    const body = "Ghost [[cite:highlight:unknown]].";
+    expect(renderBriefBodyPlain(body, evidence)).toBe(
+      "Ghost [missing citation].",
+    );
+  });
+
+  it("returns the body unchanged when it contains no citations", () => {
+    expect(renderBriefBodyPlain("Plain prose.", evidence)).toBe("Plain prose.");
+  });
+});
+
+describe("renderBriefMarkdown", () => {
+  it("emits title, body and a deduped Sources section", () => {
+    const markdown = renderBriefMarkdown(
+      {
+        title: "Risk Memo",
+        body_markdown:
+          "## Summary\n\nRevenue fell [[cite:highlight:h1]] while margins held [[cite:highlight:h2]].\n\nSee the [[cite:source:srcB]] for context.",
+      },
+      evidence,
+    );
+
+    expect(markdown).toContain("# Risk Memo");
+    expect(markdown).toContain(
+      "Revenue fell [Q3 Earnings Report, p.12] while margins held [Q3 Earnings Report, ¶4].",
+    );
+    expect(markdown).toContain("See the [Analyst Memo] for context.");
+    expect(markdown).toContain("## Sources");
+    expect(markdown).toContain("1. Q3 Earnings Report — Jane Doe, Example Corp");
+    expect(markdown).toContain("2. Analyst Memo");
+    // Sources section dedupes: h1 and h2 both reference srcA → one entry.
+    const sourcesSection = markdown.split("## Sources\n\n")[1] ?? "";
+    expect(sourcesSection.match(/Q3 Earnings Report/g)?.length).toBe(1);
+  });
+
+  it("omits the Sources section when the brief has no citations", () => {
+    const markdown = renderBriefMarkdown(
+      { title: "Empty brief", body_markdown: "Just prose, no evidence." },
+      evidence,
+    );
+    expect(markdown).toBe("# Empty brief\n\nJust prose, no evidence.\n");
+    expect(markdown).not.toContain("## Sources");
+  });
+
+  it("falls back to 'Untitled brief' when the title is blank", () => {
+    const markdown = renderBriefMarkdown(
+      { title: "   ", body_markdown: null },
+      [],
+    );
+    expect(markdown).toBe("# Untitled brief\n");
+  });
+});
+
+describe("renderBriefCitedSources", () => {
+  it("preserves first-appearance order and dedupes", () => {
+    const body =
+      "Claim [[cite:source:srcB]] and [[cite:highlight:h1]] and again [[cite:source:srcB]].";
+    const cited = renderBriefCitedSources(body, evidence);
+    expect(cited.map((s) => s.id)).toEqual(["srcB", "srcA"]);
+  });
+});
+
+describe("renderBriefBlocks", () => {
+  it("splits the body into heading and paragraph blocks with inline citations", () => {
+    const body =
+      "## Summary\n\nRevenue fell [[cite:highlight:h1]].\n\nSecond paragraph.";
+    const blocks = renderBriefBlocks(body, evidence);
+    expect(blocks).toHaveLength(3);
+    expect(blocks[0].type).toBe("heading");
+    expect(blocks[0].depth).toBe(2);
+    expect(blocks[1].type).toBe("paragraph");
+    const paragraph = blocks[1].nodes;
+    expect(paragraph[0]).toEqual({ type: "text", text: "Revenue fell " });
+    expect(paragraph[1]).toEqual({
+      type: "citation",
+      text: "[Q3 Earnings Report, p.12]",
+      resolved: true,
+    });
+  });
+
+  it("flags missing citations so the print page can style them", () => {
+    const blocks = renderBriefBlocks(
+      "Note [[cite:source:ghost]].",
+      evidence,
+    );
+    const citation = blocks[0].nodes.find((n) => n.type === "citation");
+    expect(citation).toEqual({
+      type: "citation",
+      text: "[missing citation]",
+      resolved: false,
+    });
+  });
+});
+
+describe("buildExportFilename", () => {
+  it("slugifies the brief title", () => {
+    expect(buildExportFilename("Q3 Risk Memo", "md")).toBe("q3-risk-memo.md");
+  });
+
+  it("strips punctuation and collapses separators", () => {
+    expect(buildExportFilename("U.S. / Global — Strategy!", "pdf")).toBe(
+      "u-s-global-strategy.pdf",
+    );
+  });
+
+  it("falls back to 'brief' when nothing remains", () => {
+    expect(buildExportFilename("   ", "md")).toBe("brief.md");
+    expect(buildExportFilename("!!!", "md")).toBe("brief.md");
+  });
+});

--- a/src/lib/briefExport.ts
+++ b/src/lib/briefExport.ts
@@ -1,0 +1,252 @@
+import {
+  formatHighlightAnchor,
+  segmentCitations,
+  type CitationRef,
+} from "./citations";
+
+export interface ExportHighlight {
+  id: string;
+  source_id: string;
+  page_number: number | null;
+  start_offset: number;
+  quote_text: string;
+}
+
+export interface ExportSource {
+  id: string;
+  title: string;
+  author: string | null;
+  publisher: string | null;
+  highlights: ExportHighlight[];
+}
+
+export interface ExportBrief {
+  title: string;
+  body_markdown: string | null;
+}
+
+interface ResolvedCitation {
+  sourceTitle: string;
+  anchor: string | null;
+}
+
+function resolveCitation(
+  ref: CitationRef,
+  sourceById: Map<string, ExportSource>,
+  highlightById: Map<string, { highlight: ExportHighlight; source: ExportSource }>,
+): ResolvedCitation | null {
+  if (ref.kind === "source") {
+    const source = sourceById.get(ref.id);
+    if (!source) return null;
+    return { sourceTitle: source.title, anchor: null };
+  }
+  const entry = highlightById.get(ref.id);
+  if (!entry) return null;
+  return {
+    sourceTitle: entry.source.title,
+    anchor: formatHighlightAnchor(entry.highlight),
+  };
+}
+
+function formatCitationText(resolved: ResolvedCitation | null): string {
+  if (!resolved) return "[missing citation]";
+  if (resolved.anchor) {
+    return `[${resolved.sourceTitle}, ${resolved.anchor}]`;
+  }
+  return `[${resolved.sourceTitle}]`;
+}
+
+function indexEvidence(evidence: ExportSource[]) {
+  const sourceById = new Map<string, ExportSource>();
+  const highlightById = new Map<
+    string,
+    { highlight: ExportHighlight; source: ExportSource }
+  >();
+  for (const source of evidence) {
+    sourceById.set(source.id, source);
+    for (const highlight of source.highlights) {
+      highlightById.set(highlight.id, { highlight, source });
+    }
+  }
+  return { sourceById, highlightById };
+}
+
+/**
+ * Render the brief body with inline citation markers rewritten as readable
+ * references like "[Source Title, p.12]". Citations that reference removed
+ * evidence fall back to "[missing citation]" so the output never leaks a
+ * raw marker or a silent gap.
+ */
+export function renderBriefBodyPlain(
+  body: string,
+  evidence: ExportSource[],
+): string {
+  const { sourceById, highlightById } = indexEvidence(evidence);
+  return segmentCitations(body)
+    .map((segment) => {
+      if (segment.type === "text") return segment.text;
+      const resolved = resolveCitation(segment.ref, sourceById, highlightById);
+      return formatCitationText(resolved);
+    })
+    .join("");
+}
+
+function collectCitedSources(
+  body: string,
+  evidence: ExportSource[],
+): ExportSource[] {
+  const { sourceById, highlightById } = indexEvidence(evidence);
+  const seen = new Set<string>();
+  const ordered: ExportSource[] = [];
+
+  for (const segment of segmentCitations(body)) {
+    if (segment.type !== "citation") continue;
+    let sourceId: string | null = null;
+    if (segment.ref.kind === "source") {
+      sourceId = sourceById.has(segment.ref.id) ? segment.ref.id : null;
+    } else {
+      const entry = highlightById.get(segment.ref.id);
+      sourceId = entry ? entry.source.id : null;
+    }
+    if (!sourceId || seen.has(sourceId)) continue;
+    const source = sourceById.get(sourceId);
+    if (!source) continue;
+    seen.add(sourceId);
+    ordered.push(source);
+  }
+
+  return ordered;
+}
+
+function formatSourceReference(source: ExportSource): string {
+  const attribution = [source.author, source.publisher]
+    .map((v) => v?.trim())
+    .filter((v): v is string => Boolean(v))
+    .join(", ");
+  return attribution ? `${source.title} — ${attribution}` : source.title;
+}
+
+/**
+ * Render the full brief as a Markdown document suitable for direct download.
+ * The brief title becomes the H1, the body is preserved verbatim (citation
+ * tokens are swapped for human-readable references), and a "Sources" section
+ * is appended when the brief cites anything.
+ */
+export function renderBriefMarkdown(
+  brief: ExportBrief,
+  evidence: ExportSource[],
+): string {
+  const title = brief.title.trim() || "Untitled brief";
+  const body = (brief.body_markdown ?? "").trimEnd();
+  const rendered = renderBriefBodyPlain(body, evidence);
+  const cited = collectCitedSources(body, evidence);
+
+  const parts: string[] = [`# ${title}`];
+  if (rendered.trim().length > 0) parts.push(rendered);
+  if (cited.length > 0) {
+    const list = cited
+      .map((source, index) => `${index + 1}. ${formatSourceReference(source)}`)
+      .join("\n");
+    parts.push(`## Sources\n\n${list}`);
+  }
+  return parts.join("\n\n") + "\n";
+}
+
+/**
+ * Produce a filesystem-friendly slug from the brief title for export
+ * filenames. Defaults to `brief` when nothing usable remains.
+ */
+export function buildExportFilename(title: string, extension: string): string {
+  const slug = title
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[^\p{L}\p{N}]+/gu, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+  const safe = slug || "brief";
+  return `${safe}.${extension}`;
+}
+
+export interface RenderedBodyBlock {
+  type: "heading" | "paragraph";
+  depth?: number;
+  nodes: RenderedInline[];
+}
+
+export type RenderedInline =
+  | { type: "text"; text: string }
+  | { type: "citation"; text: string; resolved: boolean };
+
+/**
+ * Split the rendered body into heading/paragraph blocks with inline citation
+ * nodes preserved. Used by the print page to render semantic HTML with
+ * styled citation chips while leaving paragraph structure intact.
+ */
+export function renderBriefBlocks(
+  body: string,
+  evidence: ExportSource[],
+): RenderedBodyBlock[] {
+  const { sourceById, highlightById } = indexEvidence(evidence);
+  const lines = (body ?? "").split("\n");
+  const blocks: RenderedBodyBlock[] = [];
+  let paragraph: RenderedInline[] = [];
+
+  const flush = () => {
+    if (paragraph.length === 0) return;
+    const hasContent = paragraph.some(
+      (node) => node.type !== "text" || node.text.trim().length > 0,
+    );
+    if (hasContent) blocks.push({ type: "paragraph", nodes: paragraph });
+    paragraph = [];
+  };
+
+  for (const line of lines) {
+    const headingMatch = /^(#{1,6})\s+(.+?)\s*$/.exec(line);
+    if (headingMatch) {
+      flush();
+      const depth = headingMatch[1].length;
+      blocks.push({
+        type: "heading",
+        depth,
+        nodes: segmentLine(headingMatch[2], sourceById, highlightById),
+      });
+      continue;
+    }
+    if (line.trim() === "") {
+      flush();
+      continue;
+    }
+    if (paragraph.length > 0) paragraph.push({ type: "text", text: " " });
+    paragraph.push(...segmentLine(line, sourceById, highlightById));
+  }
+  flush();
+
+  return blocks;
+}
+
+function segmentLine(
+  line: string,
+  sourceById: Map<string, ExportSource>,
+  highlightById: Map<string, { highlight: ExportHighlight; source: ExportSource }>,
+): RenderedInline[] {
+  return segmentCitations(line).map((segment) => {
+    if (segment.type === "text") return { type: "text", text: segment.text };
+    const resolved = resolveCitation(segment.ref, sourceById, highlightById);
+    return {
+      type: "citation",
+      text: formatCitationText(resolved),
+      resolved: resolved !== null,
+    };
+  });
+}
+
+export function renderBriefCitedSources(
+  body: string,
+  evidence: ExportSource[],
+): ExportSource[] {
+  return collectCitedSources(body, evidence);
+}
+
+export function formatSourceAttribution(source: ExportSource): string {
+  return formatSourceReference(source);
+}


### PR DESCRIPTION
## Summary

- Add server-side brief export API route at `src/app/api/dossiers/[id]/brief/export/route.ts` supporting Markdown output with citation-preserving serialization
- Introduce `src/lib/briefExport.ts` with brief-to-Markdown conversion logic (plus unit tests) that renders citation tokens, evidence blocks, and metadata into clean Markdown
- Add a print-optimized brief view at `src/app/briefs/[dossierId]/print/page.tsx` with dedicated `print.css` tuned for PDF generation via the browser's print dialog
- Wire a `BriefExportMenu` into the brief editor (via `BriefEditorClient` and `BriefPrintLauncher`) offering Markdown download and PDF-via-print actions
- Preserve the editorial aesthetic in printed output (Newsreader/IBM Plex typography, citation chip styling) so exported PDFs match the in-app brief presentation

Closes #24

## Validation

- [x] Code builds successfully
- [x] Lint passes
- [x] Typecheck passes
- [ ] Tests pass (if applicable)
- [ ] Matches design direction from product spec
