### PR TITLE
style(DOS-026): Add empty states, loading states, and motion polish

### DIFF
--- a/src/app/dossiers/[id]/activity/page.tsx
+++ b/src/app/dossiers/[id]/activity/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { EmptyState } from "@/components/ui/EmptyState";
 
 export const metadata: Metadata = {
   title: "Activity — Dossier",
@@ -22,28 +23,10 @@ export default function ActivityPage() {
         </h2>
       </div>
 
-      <div className="panel py-12 px-8 text-center">
-        <p
-          className="mb-2 max-w-none"
-          style={{
-            fontFamily: "var(--font-mono)",
-            fontSize: "0.8125rem",
-            color: "var(--color-ink-secondary)",
-          }}
-        >
-          No activity recorded.
-        </p>
-        <p
-          style={{
-            fontFamily: "var(--font-sans)",
-            fontSize: "0.875rem",
-            color: "var(--color-ink-secondary)",
-            fontStyle: "italic",
-          }}
-        >
-          Changes to sources, claims, and entities will be logged here as a research audit trail.
-        </p>
-      </div>
+      <EmptyState
+        eyebrow="No activity recorded."
+        message="Changes to sources, claims, and entities will be logged here as a research audit trail."
+      />
     </div>
   );
 }

--- a/src/app/dossiers/[id]/brief/loading.tsx
+++ b/src/app/dossiers/[id]/brief/loading.tsx
@@ -1,0 +1,73 @@
+import { Skeleton } from "@/components/ui/Skeleton";
+
+export default function BriefLoading() {
+  return (
+    <div
+      className="flex-1 flex min-h-0"
+      style={{ backgroundColor: "var(--color-bg-canvas)" }}
+    >
+      <aside
+        className="shrink-0"
+        style={{
+          width: "14rem",
+          borderRight: "var(--border-thin) solid var(--color-border)",
+          padding: "0.875rem 1rem",
+          display: "flex",
+          flexDirection: "column",
+          gap: "0.5rem",
+        }}
+      >
+        <Skeleton width="5rem" height="0.75rem" />
+        <Skeleton width="80%" height="0.75rem" />
+        <Skeleton width="60%" height="0.75rem" />
+        <Skeleton width="70%" height="0.75rem" />
+      </aside>
+
+      <section className="flex-1 min-w-0 flex flex-col">
+        <header
+          style={{
+            padding: "0.75rem var(--space-gutter)",
+            borderBottom: "var(--border-hairline) solid var(--color-border)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
+          <Skeleton width="6rem" height="0.75rem" />
+          <Skeleton width="5rem" height="0.75rem" />
+        </header>
+
+        <div
+          className="w-full mx-auto flex flex-col"
+          style={{
+            maxWidth: "40rem",
+            padding: "3rem 1.5rem 4rem",
+            gap: "1rem",
+          }}
+        >
+          <Skeleton width="50%" height="2.25rem" />
+          <Skeleton width="100%" height="1rem" />
+          <Skeleton width="95%" height="1rem" />
+          <Skeleton width="90%" height="1rem" />
+          <Skeleton width="70%" height="1rem" />
+        </div>
+      </section>
+
+      <aside
+        className="shrink-0"
+        style={{
+          width: "17rem",
+          borderLeft: "var(--border-thin) solid var(--color-border)",
+          padding: "0.875rem 1rem",
+          display: "flex",
+          flexDirection: "column",
+          gap: "0.5rem",
+        }}
+      >
+        <Skeleton width="5rem" height="0.75rem" />
+        <Skeleton width="100%" height="2.5rem" radius="var(--radius-sm)" />
+        <Skeleton width="100%" height="2.5rem" radius="var(--radius-sm)" />
+      </aside>
+    </div>
+  );
+}

--- a/src/app/dossiers/[id]/claims/loading.tsx
+++ b/src/app/dossiers/[id]/claims/loading.tsx
@@ -1,0 +1,26 @@
+import { Skeleton, SkeletonPanel } from "@/components/ui/Skeleton";
+
+export default function ClaimsLoading() {
+  return (
+    <div
+      className="mx-auto w-full"
+      style={{
+        padding: "2rem var(--space-gutter)",
+        maxWidth: "960px",
+      }}
+    >
+      <div className="flex items-center justify-between mb-4">
+        <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+          <Skeleton width="6rem" height="1.25rem" />
+          <Skeleton width="5rem" height="0.75rem" />
+        </div>
+        <Skeleton width="6rem" height="1.75rem" radius="var(--radius-sm)" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <SkeletonPanel lines={2} />
+        <SkeletonPanel lines={2} />
+        <SkeletonPanel lines={2} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/dossiers/[id]/entities/loading.tsx
+++ b/src/app/dossiers/[id]/entities/loading.tsx
@@ -1,0 +1,23 @@
+import { Skeleton, SkeletonPanel } from "@/components/ui/Skeleton";
+
+export default function EntitiesLoading() {
+  return (
+    <div
+      className="w-full max-w-[960px] mx-auto py-8"
+      style={{ paddingInline: "var(--space-gutter)" }}
+    >
+      <div className="flex items-start justify-between mb-6">
+        <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+          <Skeleton width="6rem" height="1.25rem" />
+          <Skeleton width="8rem" height="0.75rem" />
+        </div>
+        <Skeleton width="7rem" height="2rem" radius="var(--radius-sm)" />
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: "0.875rem" }}>
+        <SkeletonPanel lines={2} />
+        <SkeletonPanel lines={2} />
+        <SkeletonPanel lines={2} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/dossiers/[id]/layout.tsx
+++ b/src/app/dossiers/[id]/layout.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { auth } from "@/auth";
 import { getDossier } from "@/server/queries/dossiers";
 import { WorkspaceTabBar } from "@/components/dossiers/WorkspaceTabBar";
+import { WorkspacePaneTransition } from "@/components/dossiers/WorkspacePaneTransition";
 import { GlobalSearchBar } from "@/components/search/GlobalSearchBar";
 import { DossierWorkspaceShortcuts } from "@/components/command/DossierWorkspaceShortcuts";
 
@@ -99,7 +100,7 @@ export default async function DossierLayout({
       <div className="flex flex-1 min-h-0">
         {/* Main content region */}
         <main className="flex flex-col flex-1 min-h-0">
-          {children}
+          <WorkspacePaneTransition>{children}</WorkspacePaneTransition>
         </main>
 
         {/* Right inspector slot — collapsed by default, populated per-tab */}

--- a/src/app/dossiers/[id]/overview/loading.tsx
+++ b/src/app/dossiers/[id]/overview/loading.tsx
@@ -1,0 +1,20 @@
+import { SkeletonPanel } from "@/components/ui/Skeleton";
+
+export default function OverviewLoading() {
+  return (
+    <div
+      className="w-full max-w-[960px] mx-auto py-8"
+      style={{ paddingInline: "var(--space-gutter)" }}
+    >
+      <div className="grid grid-cols-2 gap-4 mb-4">
+        <div className="col-span-full">
+          <SkeletonPanel lines={3} />
+        </div>
+        <SkeletonPanel lines={2} />
+        <SkeletonPanel lines={2} />
+        <SkeletonPanel lines={2} />
+        <SkeletonPanel lines={2} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/dossiers/[id]/overview/page.tsx
+++ b/src/app/dossiers/[id]/overview/page.tsx
@@ -10,7 +10,7 @@ export default function OverviewPage() {
       className="w-full max-w-[960px] mx-auto py-8"
       style={{ paddingInline: "var(--space-gutter)" }}
     >
-      <div className="grid grid-cols-2 gap-4 mb-4">
+      <div className="grid grid-cols-2 gap-4 mb-4 anim-stagger">
         {/* Summary panel */}
         <div className="panel col-span-full p-6">
           <p

--- a/src/app/dossiers/[id]/sources/loading.tsx
+++ b/src/app/dossiers/[id]/sources/loading.tsx
@@ -1,0 +1,22 @@
+import { Skeleton, SkeletonPanel } from "@/components/ui/Skeleton";
+
+export default function SourcesLoading() {
+  return (
+    <div
+      className="w-full mx-auto"
+      style={{
+        padding: "2rem var(--space-gutter)",
+        maxWidth: "960px",
+      }}
+    >
+      <div className="flex items-center justify-between mb-4">
+        <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+          <Skeleton width="8rem" height="1.25rem" />
+          <Skeleton width="6rem" height="0.75rem" />
+        </div>
+        <Skeleton width="7.5rem" height="2rem" radius="var(--radius-sm)" />
+      </div>
+      <SkeletonPanel lines={6} heading={false} />
+    </div>
+  );
+}

--- a/src/app/dossiers/[id]/timeline/loading.tsx
+++ b/src/app/dossiers/[id]/timeline/loading.tsx
@@ -1,0 +1,54 @@
+import { Skeleton } from "@/components/ui/Skeleton";
+
+export default function TimelineLoading() {
+  return (
+    <div
+      className="w-full max-w-[760px] mx-auto py-8"
+      style={{ paddingInline: "var(--space-gutter)" }}
+    >
+      <div className="flex items-baseline justify-between mb-6">
+        <Skeleton width="6rem" height="1.25rem" />
+        <Skeleton width="5rem" height="0.75rem" />
+      </div>
+
+      <ol
+        className="relative pl-6"
+        style={{
+          listStyle: "none",
+          borderLeft: "var(--border-rule) solid var(--color-border)",
+          marginLeft: "0.4375rem",
+        }}
+      >
+        {[0, 1, 2, 3].map((i) => (
+          <li
+            key={i}
+            className="relative"
+            style={{
+              paddingBottom: "1.25rem",
+              display: "flex",
+              flexDirection: "column",
+              gap: "0.375rem",
+            }}
+          >
+            <span
+              aria-hidden
+              className="skeleton"
+              style={{
+                position: "absolute",
+                top: "0.4375rem",
+                left: "calc(-1 * var(--border-rule) - 5px)",
+                width: "10px",
+                height: "10px",
+                borderRadius: "9999px",
+                boxShadow: "0 0 0 3px var(--color-bg-canvas)",
+              }}
+            />
+            <Skeleton width="5rem" height="0.625rem" />
+            <Skeleton width="80%" height="1rem" />
+            <Skeleton width="60%" height="0.75rem" />
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/src/app/dossiers/[id]/timeline/page.tsx
+++ b/src/app/dossiers/[id]/timeline/page.tsx
@@ -5,6 +5,7 @@ import { auth } from "@/auth";
 import { getEvents, type EventListItem } from "@/server/queries/events";
 import { EntityChip } from "@/components/entities/EntityChip";
 import { formatEventDate } from "@/lib/events";
+import { EmptyState } from "@/components/ui/EmptyState";
 
 export const metadata: Metadata = {
   title: "Timeline — Dossier",
@@ -68,29 +69,10 @@ export default async function TimelinePage({ params }: TimelinePageProps) {
       </div>
 
       {events.length === 0 ? (
-        <div className="panel py-12 px-8 text-center">
-          <p
-            className="mb-2 max-w-none"
-            style={{
-              fontFamily: "var(--font-mono)",
-              fontSize: "0.8125rem",
-              color: "var(--color-ink-secondary)",
-            }}
-          >
-            No events on record.
-          </p>
-          <p
-            style={{
-              fontFamily: "var(--font-sans)",
-              fontSize: "0.875rem",
-              color: "var(--color-ink-secondary)",
-              fontStyle: "italic",
-            }}
-          >
-            Dated events drawn from sources and claims will be arranged
-            chronologically here.
-          </p>
-        </div>
+        <EmptyState
+          eyebrow="No events on record."
+          message="Dated events drawn from sources and claims will be arranged chronologically here."
+        />
       ) : (
         <>
           {dated.length > 0 && (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -401,3 +401,104 @@ textarea.input {
 .source-status-menu-item[data-highlighted] {
   background-color: var(--color-bg-selected);
 }
+
+/* ============================================================
+   MOTION — soft, restrained transitions only
+   ============================================================ */
+
+@keyframes tab-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes stagger-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes drawer-slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes overlay-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes timeline-focus {
+  0% { background-color: transparent; }
+  25% { background-color: var(--color-highlight-wash); }
+  100% { background-color: transparent; }
+}
+
+@keyframes subtle-pulse {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 0.85; }
+}
+
+.anim-tab-enter {
+  animation: tab-fade-in var(--duration-slow) ease-out both;
+}
+
+.anim-stagger > * {
+  opacity: 0;
+  animation: stagger-reveal var(--duration-slow) ease-out forwards;
+}
+
+.anim-stagger > *:nth-child(1) { animation-delay: 0ms; }
+.anim-stagger > *:nth-child(2) { animation-delay: 50ms; }
+.anim-stagger > *:nth-child(3) { animation-delay: 100ms; }
+.anim-stagger > *:nth-child(4) { animation-delay: 150ms; }
+.anim-stagger > *:nth-child(5) { animation-delay: 200ms; }
+.anim-stagger > *:nth-child(6) { animation-delay: 240ms; }
+.anim-stagger > *:nth-child(n+7) { animation-delay: 240ms; }
+
+.anim-drawer-enter {
+  animation: drawer-slide-in var(--duration-slow) ease-out both;
+}
+
+.anim-overlay-enter {
+  animation: overlay-fade-in var(--duration-base) ease-out both;
+}
+
+.anim-timeline-focus {
+  animation: timeline-focus 1.2s ease-out 1;
+}
+
+.skeleton {
+  background-color: var(--color-bg-selected);
+  border-radius: var(--radius-sm);
+  animation: subtle-pulse 1.6s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .anim-tab-enter,
+  .anim-stagger > *,
+  .anim-drawer-enter,
+  .anim-overlay-enter,
+  .anim-timeline-focus,
+  .skeleton {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}

--- a/src/components/claims/ClaimsClient.tsx
+++ b/src/components/claims/ClaimsClient.tsx
@@ -12,6 +12,7 @@ import {
   EntityLinkModal,
   type LinkTarget,
 } from "@/components/entities/EntityLinkModal";
+import { EmptyState } from "@/components/ui/EmptyState";
 
 interface Props {
   dossierId: string;
@@ -761,29 +762,10 @@ export function ClaimsClient({ dossierId, claims, entities }: Props) {
 
       {/* Content */}
       {claims.length === 0 ? (
-        <div className="panel py-12 px-8 text-center">
-          <p
-            className="mb-2 max-w-none"
-            style={{
-              fontFamily: "var(--font-mono)",
-              fontSize: "0.8125rem",
-              color: "var(--color-ink-secondary)",
-            }}
-          >
-            No claims recorded.
-          </p>
-          <p
-            style={{
-              fontFamily: "var(--font-sans)",
-              fontSize: "0.875rem",
-              color: "var(--color-ink-secondary)",
-              fontStyle: "italic",
-            }}
-          >
-            Claims are defensible assertions linked to source evidence. Create
-            them from highlights in the source reader.
-          </p>
-        </div>
+        <EmptyState
+          eyebrow="No claims recorded."
+          message="Claims are defensible assertions linked to source evidence. Draft them from highlights in the source reader."
+        />
       ) : viewMode === "board" ? (
         <BoardView
           claims={claims}
@@ -797,18 +779,11 @@ export function ClaimsClient({ dossierId, claims, entities }: Props) {
           onCancelEdit={() => setEditingId(null)}
         />
       ) : filtered.length === 0 ? (
-        <div className="panel p-8 text-center">
-          <p
-            className="max-w-none"
-            style={{
-              fontFamily: "var(--font-mono)",
-              fontSize: "0.8125rem",
-              color: "var(--color-ink-secondary)",
-            }}
-          >
-            No claims match the current filter.
-          </p>
-        </div>
+        <EmptyState
+          eyebrow="No claims match this filter."
+          message="Clear the filter above to see every claim in this dossier."
+          compact
+        />
       ) : (
         <div className="flex flex-col gap-2">
           {filtered.map((claim) => (

--- a/src/components/dossiers/WorkspacePaneTransition.tsx
+++ b/src/components/dossiers/WorkspacePaneTransition.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { usePathname } from "next/navigation";
+
+interface WorkspacePaneTransitionProps {
+  children: ReactNode;
+}
+
+/**
+ * Re-triggers the soft fade/slide-in animation each time the user switches
+ * workspace tabs. Keying on pathname forces React to remount the wrapper so
+ * the CSS animation replays on every navigation.
+ */
+export function WorkspacePaneTransition({
+  children,
+}: WorkspacePaneTransitionProps) {
+  const pathname = usePathname();
+
+  return (
+    <div
+      key={pathname}
+      className="anim-tab-enter flex flex-col flex-1 min-h-0"
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/entities/EntitiesClient.tsx
+++ b/src/components/entities/EntitiesClient.tsx
@@ -11,6 +11,7 @@ import { EntityChip } from "./EntityChip";
 import { EntityEditorModal } from "./EntityEditorModal";
 import { EntityDetailDrawer } from "./EntityDetailDrawer";
 import { formatEntityAliases } from "@/lib/entities";
+import { EmptyState } from "@/components/ui/EmptyState";
 
 interface EntitiesClientProps {
   dossierId: string;
@@ -105,37 +106,19 @@ export function EntitiesClient({
         </div>
 
         {entities.length === 0 ? (
-          <div className="panel py-12 px-8 text-center">
-            <p
-              className="mb-2 max-w-none"
-              style={{
-                fontFamily: "var(--font-mono)",
-                fontSize: "0.8125rem",
-                color: "var(--color-ink-secondary)",
-              }}
-            >
-              No entities identified.
-            </p>
-            <p
-              style={{
-                fontFamily: "var(--font-sans)",
-                fontSize: "0.875rem",
-                color: "var(--color-ink-secondary)",
-                fontStyle: "italic",
-                marginBottom: "1rem",
-              }}
-            >
-              Promote the people, companies, products, locations, institutions,
-              and topics that recur across your research.
-            </p>
-            <button
-              type="button"
-              className="btn btn-secondary"
-              onClick={() => setEditorOpen(true)}
-            >
-              Create First Entity
-            </button>
-          </div>
+          <EmptyState
+            eyebrow="No entities identified."
+            message="Promote the people, companies, products, locations, institutions, and topics that recur across your research."
+            action={
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={() => setEditorOpen(true)}
+              >
+                Create first entity
+              </button>
+            }
+          />
         ) : (
           <div
             style={{

--- a/src/components/entities/EntityDetailDrawer.tsx
+++ b/src/components/entities/EntityDetailDrawer.tsx
@@ -152,6 +152,7 @@ export function EntityDetailDrawer({
       <div
         aria-hidden="true"
         onClick={onClose}
+        className="anim-overlay-enter"
         style={{
           position: "fixed",
           inset: 0,
@@ -168,6 +169,7 @@ export function EntityDetailDrawer({
         aria-labelledby={titleId}
         aria-describedby={descriptionId}
         tabIndex={-1}
+        className="anim-drawer-enter"
         style={{
           position: "fixed",
           top: 0,

--- a/src/components/sources/SourcesClient.tsx
+++ b/src/components/sources/SourcesClient.tsx
@@ -9,6 +9,7 @@ import { SourceStatusMenu } from "./SourceStatusMenu";
 import { updateSourceStatus } from "@/server/actions/sources";
 import type { SourceListItem } from "@/server/queries/sources";
 import type { SourceType, SourceStatus } from "@prisma/client";
+import { EmptyState } from "@/components/ui/EmptyState";
 
 interface Props {
   dossierId: string;
@@ -217,56 +218,25 @@ export function SourcesClient({ dossierId, sources }: Props) {
 
       {/* Content */}
       {sources.length === 0 ? (
-        <div
-          className="panel"
-          style={{
-            padding: "3rem 2rem",
-            textAlign: "center",
-          }}
-        >
-          <p
-            style={{
-              fontFamily: "var(--font-mono)",
-              fontSize: "0.8125rem",
-              color: "var(--color-ink-secondary)",
-              marginBottom: "0.5rem",
-              maxWidth: "none",
-            }}
-          >
-            No sources yet.
-          </p>
-          <p
-            style={{
-              fontFamily: "var(--font-sans)",
-              fontSize: "0.875rem",
-              color: "var(--color-ink-secondary)",
-              fontStyle: "italic",
-              maxWidth: "none",
-            }}
-          >
-            Add a URL, paste text, or write a note to begin building your
-            evidence base.
-          </p>
-        </div>
+        <EmptyState
+          eyebrow="No sources yet."
+          message="Capture a URL, paste text, or write a note to begin building your evidence base."
+          action={
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={() => setModalOpen(true)}
+            >
+              Capture first source
+            </button>
+          }
+        />
       ) : filtered.length === 0 ? (
-        <div
-          className="panel"
-          style={{
-            padding: "2rem",
-            textAlign: "center",
-          }}
-        >
-          <p
-            style={{
-              fontFamily: "var(--font-mono)",
-              fontSize: "0.8125rem",
-              color: "var(--color-ink-secondary)",
-              maxWidth: "none",
-            }}
-          >
-            No sources match the current filters.
-          </p>
-        </div>
+        <EmptyState
+          eyebrow="No sources match these filters."
+          message="Adjust the type or status filters above to see more."
+          compact
+        />
       ) : (
         <div
           className="panel"

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -1,0 +1,84 @@
+import type { ReactNode } from "react";
+
+interface EmptyStateProps {
+  /** Short mono-style eyebrow label (e.g. "No sources yet.") */
+  eyebrow: string;
+  /** Supporting sentence in serif italic voice */
+  message: string;
+  /** Optional single-character glyph rendered as an ornament above the copy */
+  glyph?: string;
+  /** Optional call-to-action slot (e.g. a primary button) */
+  action?: ReactNode;
+  /** Dense version for narrow inspector columns and cards */
+  compact?: boolean;
+}
+
+/**
+ * EmptyState — editorial "no data" primitive used across workspace tabs.
+ *
+ * The form imitates a printed masthead: ruled ornament, mono eyebrow,
+ * serif-italic voice. Use for any view that can be entirely empty.
+ */
+export function EmptyState({
+  eyebrow,
+  message,
+  glyph = "§",
+  action,
+  compact = false,
+}: EmptyStateProps) {
+  return (
+    <div
+      className="panel anim-tab-enter"
+      style={{
+        padding: compact ? "1.75rem 1.25rem" : "3rem 2rem",
+        textAlign: "center",
+      }}
+    >
+      <div
+        aria-hidden
+        style={{
+          fontFamily: "var(--font-display)",
+          fontSize: compact ? "1.125rem" : "1.375rem",
+          color: "var(--color-border)",
+          letterSpacing: "0.12em",
+          marginBottom: compact ? "0.625rem" : "0.875rem",
+        }}
+      >
+        {glyph}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{glyph}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{glyph}
+      </div>
+
+      <p
+        className="max-w-none"
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: compact ? "0.75rem" : "0.8125rem",
+          color: "var(--color-ink-secondary)",
+          letterSpacing: "0.02em",
+          marginBottom: "0.5rem",
+        }}
+      >
+        {eyebrow}
+      </p>
+
+      <p
+        className="mx-auto"
+        style={{
+          fontFamily: "var(--font-sans)",
+          fontSize: compact ? "0.8125rem" : "0.875rem",
+          color: "var(--color-ink-secondary)",
+          fontStyle: "italic",
+          lineHeight: 1.55,
+          maxWidth: "36ch",
+        }}
+      >
+        {message}
+      </p>
+
+      {action && (
+        <div style={{ marginTop: "1.125rem", display: "inline-flex" }}>
+          {action}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,0 +1,73 @@
+import type { CSSProperties } from "react";
+
+interface SkeletonProps {
+  width?: string | number;
+  height?: string | number;
+  /** Override border radius — defaults to token --radius-sm */
+  radius?: string;
+  /** Optional extra classes */
+  className?: string;
+  style?: CSSProperties;
+}
+
+/**
+ * Skeleton — subtle breathing placeholder block.
+ *
+ * Uses a gentle opacity pulse (no shimmer sweep). Respects reduced motion.
+ */
+export function Skeleton({
+  width = "100%",
+  height = "1rem",
+  radius,
+  className = "",
+  style,
+}: SkeletonProps) {
+  return (
+    <span
+      aria-hidden
+      className={`skeleton ${className}`.trim()}
+      style={{
+        display: "block",
+        width,
+        height,
+        borderRadius: radius,
+        ...style,
+      }}
+    />
+  );
+}
+
+interface SkeletonPanelProps {
+  /** Number of line rows to render inside the panel */
+  lines?: number;
+  /** Add a taller head row (e.g. title) */
+  heading?: boolean;
+  compact?: boolean;
+}
+
+export function SkeletonPanel({
+  lines = 3,
+  heading = true,
+  compact = false,
+}: SkeletonPanelProps) {
+  return (
+    <div
+      className="panel"
+      style={{
+        padding: compact ? "1rem 1.125rem" : "1.25rem 1.5rem",
+        display: "flex",
+        flexDirection: "column",
+        gap: "0.625rem",
+      }}
+    >
+      {heading && <Skeleton width="40%" height="0.875rem" />}
+      {Array.from({ length: lines }).map((_, i) => (
+        <Skeleton
+          key={i}
+          width={i === lines - 1 ? "60%" : "100%"}
+          height="0.75rem"
+        />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add reusable `EmptyState` and `Skeleton` primitives plus shared CSS tokens/animations for consistent loading and empty UI across the workspace
- Introduce route-level `loading.tsx` files for overview, sources, claims, entities, timeline, and brief so each pane streams in with tailored skeletons
- Replace ad-hoc empty/loading blocks in Sources, Claims, Entities, Activity, and Timeline clients with the new `EmptyState` component for a unified editorial look
- Add `WorkspacePaneTransition` and wire it into the dossier layout to give pane changes a subtle fade/slide motion
- Polish supporting details (entity drawer, overview page, globals) to align with the new motion and empty-state patterns

Closes #26

## Validation

- [x] Code builds successfully
- [x] Lint passes
- [x] Typecheck passes
- [ ] Tests pass (if applicable)
- [ ] Matches design direction from product spec
