### PR TITLE
fix(DOS-027): Hardening pass: autosave, validation, and failure handling

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
+import { LIMITS } from "@/lib/validation";
 import {
   SEARCH_OBJECT_TYPES,
   searchWorkspace,
@@ -19,6 +20,13 @@ export async function GET(req: NextRequest) {
   const dossierId = searchParams.get("dossierId")?.trim() || null;
   const typesParam = searchParams.get("types")?.trim();
 
+  if (query.length > LIMITS.searchQuery) {
+    return NextResponse.json(
+      { error: `Query must be under ${LIMITS.searchQuery} characters.` },
+      { status: 400 },
+    );
+  }
+
   const types = typesParam
     ? typesParam
         .split(",")
@@ -28,10 +36,16 @@ export async function GET(req: NextRequest) {
         )
     : undefined;
 
-  const results = await searchWorkspace(session.user.id, query, {
-    dossierId,
-    types,
-  });
-
-  return NextResponse.json(results);
+  try {
+    const results = await searchWorkspace(session.user.id, query, {
+      dossierId,
+      types,
+    });
+    return NextResponse.json(results);
+  } catch {
+    return NextResponse.json(
+      { error: "Search failed. Please try again." },
+      { status: 500 },
+    );
+  }
 }

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -2,7 +2,9 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { auth } from "@/auth";
+import { LIMITS } from "@/lib/validation";
 import { getDossier } from "@/server/queries/dossiers";
+import type { SearchResults as SearchResultsData } from "@/server/queries/search";
 import { searchWorkspace } from "@/server/queries/search";
 import { GlobalSearchBar } from "@/components/search/GlobalSearchBar";
 import { SearchResults } from "@/components/search/SearchResults";
@@ -25,7 +27,9 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
   }
 
   const { q, dossierId } = await searchParams;
-  const query = q?.trim() ?? "";
+  // Cap server-rendered queries at the same length as the API route so a
+  // pasted query that's too long fails gracefully instead of 500-ing.
+  const query = (q?.trim() ?? "").slice(0, LIMITS.searchQuery);
 
   // Validate the scoped dossier — if the id is unknown to this user, drop the
   // scope rather than silently returning empty results.
@@ -35,24 +39,32 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
   }
   const effectiveDossierId = scopedDossier?.id ?? null;
 
-  const results = query
-    ? await searchWorkspace(session.user.id, query, {
+  const emptyResults: SearchResultsData = {
+    query,
+    dossierId: effectiveDossierId,
+    types: [],
+    groups: {
+      dossier: [],
+      source: [],
+      highlight: [],
+      claim: [],
+      entity: [],
+      brief: [],
+    },
+    total: 0,
+  };
+
+  let results: SearchResultsData = emptyResults;
+  let searchError: string | null = null;
+  if (query) {
+    try {
+      results = await searchWorkspace(session.user.id, query, {
         dossierId: effectiveDossierId,
-      })
-    : {
-        query: "",
-        dossierId: effectiveDossierId,
-        types: [],
-        groups: {
-          dossier: [],
-          source: [],
-          highlight: [],
-          claim: [],
-          entity: [],
-          brief: [],
-        },
-        total: 0,
-      };
+      });
+    } catch {
+      searchError = "Search failed. Please try again.";
+    }
+  }
 
   return (
     <main
@@ -122,10 +134,27 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
           )}
         </header>
 
-        <SearchResults
-          results={results}
-          dossierTitle={scopedDossier?.title ?? null}
-        />
+        {searchError ? (
+          <div
+            role="alert"
+            style={{
+              padding: "0.75rem 1rem",
+              backgroundColor: "var(--color-error-bg)",
+              border: "var(--border-thin) solid var(--color-error-border)",
+              borderRadius: "var(--radius-sm)",
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.8125rem",
+              color: "var(--color-accent-alert)",
+            }}
+          >
+            {searchError}
+          </div>
+        ) : (
+          <SearchResults
+            results={results}
+            dossierTitle={scopedDossier?.title ?? null}
+          />
+        )}
       </div>
     </main>
   );

--- a/src/components/claims/ClaimsClient.tsx
+++ b/src/components/claims/ClaimsClient.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useState, useMemo, useTransition, useRef, useEffect } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
 import Link from "next/link";
 import { deleteClaim, updateClaim } from "@/server/actions/claims";
 import type { ClaimListItem } from "@/server/queries/claims";
@@ -80,42 +87,153 @@ function ConfidenceIndicator({ value }: { value: number | null }) {
 
 /* ─── Inline Edit Form ──────────────────────────────────────────── */
 
+type InlineSaveStatus = "saved" | "dirty" | "saving" | "error";
+
+const CLAIM_AUTOSAVE_DELAY_MS = 800;
+
+interface InlineEditPayload {
+  statement: string;
+  confidence: number | null;
+  notes: string | null;
+}
+
 function InlineEditForm({
   claim,
-  onSave,
-  onCancel,
+  onPersist,
+  onDone,
 }: {
   claim: ClaimListItem;
-  onSave: (data: {
-    statement: string;
-    confidence: number | null;
-    notes: string | null;
-  }) => void;
-  onCancel: () => void;
+  onPersist: (
+    id: string,
+    data: InlineEditPayload,
+  ) => Promise<{ error?: string }>;
+  onDone: () => void;
 }) {
   const [statement, setStatement] = useState(claim.statement);
   const [confidence, setConfidence] = useState(
     claim.confidence != null ? String(claim.confidence) : "",
   );
   const [notes, setNotes] = useState(claim.notes ?? "");
+  const [status, setStatus] = useState<InlineSaveStatus>("saved");
+  const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  const initialSnapshot = useRef<InlineEditPayload>({
+    statement: claim.statement,
+    confidence: claim.confidence ?? null,
+    notes: claim.notes ?? null,
+  });
+  // Track the last successfully persisted values so the autosave effect
+  // can ignore re-renders that carry no real user edit.
+  const lastPersistedRef = useRef<InlineEditPayload>({
+    statement: claim.statement,
+    confidence: claim.confidence ?? null,
+    notes: claim.notes ?? null,
+  });
 
   useEffect(() => {
     inputRef.current?.focus();
     inputRef.current?.select();
   }, []);
 
-  const handleSubmit = () => {
-    if (!statement.trim()) return;
-    const conf = confidence.trim()
-      ? Math.max(0, Math.min(100, parseInt(confidence, 10)))
-      : null;
-    onSave({
-      statement: statement.trim(),
-      confidence: Number.isNaN(conf) ? null : conf,
-      notes: notes.trim() || null,
-    });
+  const parseConfidence = (raw: string): number | null => {
+    if (!raw.trim()) return null;
+    const parsed = parseInt(raw, 10);
+    if (Number.isNaN(parsed)) return null;
+    return Math.max(0, Math.min(100, parsed));
   };
+
+  const persist = useCallback(
+    async (payload: InlineEditPayload) => {
+      setStatus("saving");
+      setError(null);
+      const result = await onPersist(claim.id, payload);
+      if (result?.error) {
+        setStatus("error");
+        setError(result.error);
+        return;
+      }
+      lastPersistedRef.current = payload;
+      setStatus("saved");
+    },
+    [claim.id, onPersist],
+  );
+
+  // Debounced autosave: only fires on a genuine drift from the last save.
+  useEffect(() => {
+    const trimmedStatement = statement.trim();
+    const parsedConfidence = parseConfidence(confidence);
+    const trimmedNotes = notes.trim() || null;
+
+    const snapshot = lastPersistedRef.current;
+    if (
+      trimmedStatement === snapshot.statement &&
+      parsedConfidence === snapshot.confidence &&
+      trimmedNotes === snapshot.notes
+    ) {
+      return;
+    }
+
+    if (!trimmedStatement) {
+      setStatus("error");
+      setError("Statement is required.");
+      return;
+    }
+
+    setStatus("dirty");
+    setError(null);
+    const handle = window.setTimeout(() => {
+      persist({
+        statement: trimmedStatement,
+        confidence: parsedConfidence,
+        notes: trimmedNotes,
+      });
+    }, CLAIM_AUTOSAVE_DELAY_MS);
+
+    return () => window.clearTimeout(handle);
+  }, [statement, confidence, notes, persist]);
+
+  // Warn before leaving the page if the user has unsaved edits.
+  useEffect(() => {
+    const handler = (event: BeforeUnloadEvent) => {
+      if (status === "saved") return;
+      event.preventDefault();
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [status]);
+
+  const handleDone = () => {
+    if (status !== "saved") {
+      const initial = initialSnapshot.current;
+      const warning =
+        status === "error"
+          ? "Discard unsaved changes? The last save failed."
+          : "Changes are still saving. Close anyway?";
+      if (!window.confirm(warning)) return;
+      // Reset to the last persisted snapshot so an incoming parent refresh
+      // doesn't show stale edits.
+      setStatement(initial.statement);
+      setConfidence(initial.confidence != null ? String(initial.confidence) : "");
+      setNotes(initial.notes ?? "");
+    }
+    onDone();
+  };
+
+  const statusLabel = (() => {
+    switch (status) {
+      case "saving":
+        return "Saving…";
+      case "dirty":
+        return "Unsaved…";
+      case "error":
+        return error ?? "Save failed";
+      case "saved":
+      default:
+        return "Saved";
+    }
+  })();
 
   return (
     <div className="flex flex-col gap-2">
@@ -125,11 +243,11 @@ function InlineEditForm({
         value={statement}
         onChange={(e) => setStatement(e.target.value)}
         onKeyDown={(e) => {
-          if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) handleSubmit();
-          if (e.key === "Escape") onCancel();
+          if (e.key === "Escape") handleDone();
         }}
         rows={2}
         style={{ minHeight: "2.5rem", fontSize: "0.9375rem" }}
+        aria-invalid={status === "error" || undefined}
       />
       <div className="flex items-center gap-3">
         <label
@@ -167,28 +285,25 @@ function InlineEditForm({
         <button
           type="button"
           className="btn btn-primary"
-          onClick={handleSubmit}
+          onClick={handleDone}
           style={{ fontSize: "0.75rem", padding: "0.25rem 0.625rem" }}
+          disabled={status === "saving" || status === "dirty"}
         >
-          Save
-        </button>
-        <button
-          type="button"
-          className="btn btn-ghost"
-          onClick={onCancel}
-          style={{ fontSize: "0.75rem", padding: "0.25rem 0.625rem" }}
-        >
-          Cancel
+          Done
         </button>
         <span
-          className="ml-auto"
+          role="status"
+          aria-live="polite"
           style={{
             fontFamily: "var(--font-mono)",
             fontSize: "0.625rem",
-            color: "var(--color-ink-secondary)",
+            color:
+              status === "error"
+                ? "var(--color-accent-alert)"
+                : "var(--color-ink-secondary)",
           }}
         >
-          ⌘+Enter to save
+          {statusLabel}
         </span>
       </div>
     </div>
@@ -206,8 +321,8 @@ function ClaimCard({
   onDelete,
   onLinkEntity,
   editingId,
-  onSaveEdit,
-  onCancelEdit,
+  onPersistEdit,
+  onFinishEdit,
 }: {
   claim: ClaimListItem;
   dossierId: string;
@@ -217,15 +332,11 @@ function ClaimCard({
   onDelete: (id: string) => void;
   onLinkEntity: (claim: ClaimListItem) => void;
   editingId: string | null;
-  onSaveEdit: (
+  onPersistEdit: (
     id: string,
-    data: {
-      statement: string;
-      confidence: number | null;
-      notes: string | null;
-    },
-  ) => void;
-  onCancelEdit: () => void;
+    data: InlineEditPayload,
+  ) => Promise<{ error?: string }>;
+  onFinishEdit: () => void;
 }) {
   const isEditing = editingId === claim.id;
   const linkedEntities = claim.entities.map((claimEntity) => claimEntity.entity);
@@ -241,8 +352,8 @@ function ClaimCard({
       {isEditing ? (
         <InlineEditForm
           claim={claim}
-          onSave={(data) => onSaveEdit(claim.id, data)}
-          onCancel={onCancelEdit}
+          onPersist={onPersistEdit}
+          onDone={onFinishEdit}
         />
       ) : (
         <div className="flex items-start justify-between gap-3">
@@ -468,8 +579,8 @@ function BoardView({
   onDelete,
   onLinkEntity,
   editingId,
-  onSaveEdit,
-  onCancelEdit,
+  onPersistEdit,
+  onFinishEdit,
 }: {
   claims: ClaimListItem[];
   dossierId: string;
@@ -478,15 +589,11 @@ function BoardView({
   onDelete: (id: string) => void;
   onLinkEntity: (claim: ClaimListItem) => void;
   editingId: string | null;
-  onSaveEdit: (
+  onPersistEdit: (
     id: string,
-    data: {
-      statement: string;
-      confidence: number | null;
-      notes: string | null;
-    },
-  ) => void;
-  onCancelEdit: () => void;
+    data: InlineEditPayload,
+  ) => Promise<{ error?: string }>;
+  onFinishEdit: () => void;
 }) {
   const columns = useMemo(() => {
     const grouped: Record<ClaimStatus, ClaimListItem[]> = {
@@ -565,8 +672,8 @@ function BoardView({
                   onDelete={onDelete}
                   onLinkEntity={onLinkEntity}
                   editingId={editingId}
-                  onSaveEdit={onSaveEdit}
-                  onCancelEdit={onCancelEdit}
+                  onPersistEdit={onPersistEdit}
+                  onFinishEdit={onFinishEdit}
                 />
               ))
             )}
@@ -586,6 +693,14 @@ export function ClaimsClient({ dossierId, claims, entities }: Props) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [linkTargetClaimId, setLinkTargetClaimId] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const flashError = useCallback((message: string) => {
+    setActionError(message);
+    window.setTimeout(() => {
+      setActionError((current) => (current === message ? null : current));
+    }, 4000);
+  }, []);
 
   const filtered = useMemo(() => {
     if (filterStatus === "all") return claims;
@@ -617,7 +732,11 @@ export function ClaimsClient({ dossierId, claims, entities }: Props) {
 
   const handleStatusChange = (claimId: string, newStatus: ClaimStatus) => {
     startTransition(async () => {
-      await updateClaim({ id: claimId, status: newStatus });
+      const result = await updateClaim({ id: claimId, status: newStatus });
+      if ("error" in result) {
+        flashError(result.error);
+        return;
+      }
       router.refresh();
     });
   };
@@ -625,30 +744,40 @@ export function ClaimsClient({ dossierId, claims, entities }: Props) {
   const handleDelete = (claimId: string) => {
     if (!window.confirm("Delete this claim? This cannot be undone.")) return;
     startTransition(async () => {
-      await deleteClaim(claimId);
+      const result = await deleteClaim(claimId);
+      if ("error" in result) {
+        flashError(result.error);
+        return;
+      }
       router.refresh();
     });
   };
 
-  const handleSaveEdit = (
-    claimId: string,
-    data: {
-      statement: string;
-      confidence: number | null;
-      notes: string | null;
-    },
-  ) => {
-    setEditingId(null);
-    startTransition(async () => {
-      await updateClaim({
+  // Called by the inline editor on every debounced autosave. Returning
+  // `{ error }` lets the editor surface the message inline while the
+  // list-level banner keeps track of the last failure too.
+  const handlePersistEdit = useCallback(
+    async (
+      claimId: string,
+      data: InlineEditPayload,
+    ): Promise<{ error?: string }> => {
+      const result = await updateClaim({
         id: claimId,
         statement: data.statement,
         confidence: data.confidence,
         notes: data.notes,
       });
+      if ("error" in result) {
+        flashError(result.error);
+        return { error: result.error };
+      }
       router.refresh();
-    });
-  };
+      return {};
+    },
+    [flashError, router],
+  );
+
+  const handleFinishEdit = useCallback(() => setEditingId(null), []);
 
   return (
     <div
@@ -660,6 +789,23 @@ export function ClaimsClient({ dossierId, claims, entities }: Props) {
         transition: "opacity var(--duration-fast) ease",
       }}
     >
+      {actionError && (
+        <div
+          role="alert"
+          style={{
+            padding: "0.75rem 1rem",
+            marginBottom: "1rem",
+            backgroundColor: "var(--color-error-bg)",
+            border: "var(--border-thin) solid var(--color-error-border)",
+            borderRadius: "var(--radius-sm)",
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.8125rem",
+            color: "var(--color-accent-alert)",
+          }}
+        >
+          {actionError}
+        </div>
+      )}
       {/* Header */}
       <div className="flex items-center justify-between mb-4">
         <div>
@@ -793,8 +939,8 @@ export function ClaimsClient({ dossierId, claims, entities }: Props) {
           onDelete={handleDelete}
           onLinkEntity={(claim) => setLinkTargetClaimId(claim.id)}
           editingId={editingId}
-          onSaveEdit={handleSaveEdit}
-          onCancelEdit={() => setEditingId(null)}
+          onPersistEdit={handlePersistEdit}
+          onFinishEdit={handleFinishEdit}
         />
       ) : filtered.length === 0 ? (
         <div className="panel p-8 text-center">
@@ -821,8 +967,8 @@ export function ClaimsClient({ dossierId, claims, entities }: Props) {
               onDelete={handleDelete}
               onLinkEntity={(claim) => setLinkTargetClaimId(claim.id)}
               editingId={editingId}
-              onSaveEdit={handleSaveEdit}
-              onCancelEdit={() => setEditingId(null)}
+              onPersistEdit={handlePersistEdit}
+              onFinishEdit={handleFinishEdit}
             />
           ))}
         </div>

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,35 @@
+// Shared field-length limits for server-side validation. Values match the
+// intent of user-entered text (short identifier vs. long-form note) and
+// guard against runaway inputs causing DB errors or UI damage.
+
+export const LIMITS = {
+  dossierTitle: 200,
+  dossierSummary: 1_000,
+  dossierResearchGoal: 500,
+  sourceTitle: 300,
+  sourceAuthor: 200,
+  sourcePublisher: 200,
+  sourceSummary: 2_000,
+  sourceUrl: 2_000,
+  sourceRawText: 1_000_000,
+  claimStatement: 1_000,
+  claimNotes: 5_000,
+  entityName: 200,
+  entityDescription: 2_000,
+  entityAlias: 200,
+  entityAliasCount: 20,
+  eventTitle: 300,
+  eventDescription: 2_000,
+  highlightQuote: 10_000,
+  highlightAnnotation: 2_000,
+  briefTitle: 200,
+  briefBody: 200_000,
+  searchQuery: 200,
+} as const;
+
+export function overLimit(
+  value: string | null | undefined,
+  max: number,
+): boolean {
+  return !!value && value.length > max;
+}

--- a/src/server/actions/briefs.ts
+++ b/src/server/actions/briefs.ts
@@ -2,6 +2,7 @@
 
 import { auth } from "@/auth";
 import { db } from "@/lib/db";
+import { LIMITS } from "@/lib/validation";
 
 interface SaveBriefInput {
   dossierId: string;
@@ -14,8 +15,8 @@ interface SaveBriefSuccess {
   updatedAt: string;
 }
 
-const MAX_TITLE_LENGTH = 200;
-const MAX_BODY_LENGTH = 200_000;
+const MAX_TITLE_LENGTH = LIMITS.briefTitle;
+const MAX_BODY_LENGTH = LIMITS.briefBody;
 
 export async function saveBrief(
   input: SaveBriefInput,

--- a/src/server/actions/claims.ts
+++ b/src/server/actions/claims.ts
@@ -2,6 +2,7 @@
 
 import { auth } from "@/auth";
 import { db } from "@/lib/db";
+import { LIMITS, overLimit } from "@/lib/validation";
 import { revalidatePath } from "next/cache";
 import type { ClaimStatus } from "@prisma/client";
 
@@ -29,6 +30,12 @@ export async function createClaim(
 
   if (!input.dossierId) return { error: "Dossier ID is required." };
   if (!input.statement?.trim()) return { error: "Statement is required." };
+  if (overLimit(input.statement, LIMITS.claimStatement))
+    return {
+      error: `Statement must be under ${LIMITS.claimStatement} characters.`,
+    };
+  if (overLimit(input.notes, LIMITS.claimNotes))
+    return { error: `Notes must be under ${LIMITS.claimNotes} characters.` };
   if (input.status && !VALID_STATUSES.includes(input.status))
     return { error: `Invalid status. Must be one of: ${VALID_STATUSES.join(", ")}.` };
   if (
@@ -101,6 +108,12 @@ export async function updateClaim(
   if (!input.id) return { error: "Claim ID is required." };
   if (input.statement !== undefined && !input.statement.trim())
     return { error: "Statement cannot be empty." };
+  if (overLimit(input.statement, LIMITS.claimStatement))
+    return {
+      error: `Statement must be under ${LIMITS.claimStatement} characters.`,
+    };
+  if (overLimit(input.notes, LIMITS.claimNotes))
+    return { error: `Notes must be under ${LIMITS.claimNotes} characters.` };
   if (input.status && !VALID_STATUSES.includes(input.status))
     return { error: `Invalid status. Must be one of: ${VALID_STATUSES.join(", ")}.` };
   if (

--- a/src/server/actions/dossiers.ts
+++ b/src/server/actions/dossiers.ts
@@ -2,6 +2,7 @@
 
 import { auth } from "@/auth";
 import { db } from "@/lib/db";
+import { LIMITS, overLimit } from "@/lib/validation";
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 
@@ -35,10 +36,17 @@ export async function createDossier(
 
   const title = (formData.get("title") as string)?.trim();
   if (!title) return "Title is required.";
+  if (title.length > LIMITS.dossierTitle)
+    return `Title must be under ${LIMITS.dossierTitle} characters.`;
 
   const summary = (formData.get("summary") as string)?.trim() || null;
+  if (overLimit(summary, LIMITS.dossierSummary))
+    return `Summary must be under ${LIMITS.dossierSummary} characters.`;
+
   const research_goal =
     (formData.get("research_goal") as string)?.trim() || null;
+  if (overLimit(research_goal, LIMITS.dossierResearchGoal))
+    return `Research goal must be under ${LIMITS.dossierResearchGoal} characters.`;
 
   let dossierId: string;
   try {
@@ -66,6 +74,8 @@ export async function renameDossier(id: string, title: string): Promise<void> {
 
   const trimmed = title.trim();
   if (!trimmed) throw new Error("Title is required");
+  if (trimmed.length > LIMITS.dossierTitle)
+    throw new Error(`Title must be under ${LIMITS.dossierTitle} characters.`);
 
   const dossier = await db.dossier.findFirst({
     where: { id, owner_id: session.user.id },

--- a/src/server/actions/entities.ts
+++ b/src/server/actions/entities.ts
@@ -3,6 +3,7 @@
 import { auth } from "@/auth";
 import { buildContextSnippet } from "@/lib/entities";
 import { db } from "@/lib/db";
+import { LIMITS, overLimit } from "@/lib/validation";
 import {
   getEntityBacklink,
   type EntityBacklinkItem,
@@ -49,6 +50,25 @@ function isValidImportance(value: number | null | undefined): boolean {
   return value == null || (value >= 0 && value <= 100);
 }
 
+function validateEntityFieldLengths(
+  input: Partial<Pick<CreateEntityInput, "name" | "description" | "aliases">>,
+): string | null {
+  if (overLimit(input.name, LIMITS.entityName))
+    return `Name must be under ${LIMITS.entityName} characters.`;
+  if (overLimit(input.description, LIMITS.entityDescription))
+    return `Description must be under ${LIMITS.entityDescription} characters.`;
+  if (input.aliases) {
+    if (input.aliases.length > LIMITS.entityAliasCount)
+      return `No more than ${LIMITS.entityAliasCount} aliases are supported.`;
+    for (const alias of input.aliases) {
+      if (alias.length > LIMITS.entityAlias) {
+        return `Each alias must be under ${LIMITS.entityAlias} characters.`;
+      }
+    }
+  }
+  return null;
+}
+
 function getTargetCount(input: LinkEntityInput): number {
   return [input.sourceId, input.highlightId, input.claimId].filter(Boolean)
     .length;
@@ -91,6 +111,8 @@ export async function createEntity(
     };
   if (!isValidImportance(input.importance))
     return { error: "Importance must be between 0 and 100." };
+  const lengthError = validateEntityFieldLengths(input);
+  if (lengthError) return { error: lengthError };
 
   const dossier = await db.dossier.findFirst({
     where: { id: input.dossierId, owner_id: session.user.id },
@@ -133,6 +155,8 @@ export async function updateEntity(
     };
   if (!isValidImportance(input.importance))
     return { error: "Importance must be between 0 and 100." };
+  const lengthError = validateEntityFieldLengths(input);
+  if (lengthError) return { error: lengthError };
 
   const entity = await db.entity.findFirst({
     where: {

--- a/src/server/actions/events.ts
+++ b/src/server/actions/events.ts
@@ -2,6 +2,7 @@
 
 import { auth } from "@/auth";
 import { db } from "@/lib/db";
+import { LIMITS, overLimit } from "@/lib/validation";
 import { revalidatePath } from "next/cache";
 import type { EventPrecision } from "@prisma/client";
 
@@ -80,6 +81,12 @@ export async function createEvent(
 
   if (!input.dossierId) return { error: "Dossier ID is required." };
   if (!input.title?.trim()) return { error: "Event title is required." };
+  if (overLimit(input.title, LIMITS.eventTitle))
+    return { error: `Title must be under ${LIMITS.eventTitle} characters.` };
+  if (overLimit(input.description, LIMITS.eventDescription))
+    return {
+      error: `Description must be under ${LIMITS.eventDescription} characters.`,
+    };
   const precision: EventPrecision = input.precision ?? "unknown";
   if (!VALID_PRECISIONS.includes(precision))
     return {
@@ -165,6 +172,12 @@ export async function updateEvent(
   if (!input.id) return { error: "Event ID is required." };
   if (input.title !== undefined && !input.title.trim())
     return { error: "Event title cannot be empty." };
+  if (overLimit(input.title, LIMITS.eventTitle))
+    return { error: `Title must be under ${LIMITS.eventTitle} characters.` };
+  if (overLimit(input.description, LIMITS.eventDescription))
+    return {
+      error: `Description must be under ${LIMITS.eventDescription} characters.`,
+    };
   if (input.precision && !VALID_PRECISIONS.includes(input.precision))
     return {
       error: `Invalid precision. Must be one of: ${VALID_PRECISIONS.join(", ")}.`,

--- a/src/server/actions/highlights.ts
+++ b/src/server/actions/highlights.ts
@@ -2,6 +2,7 @@
 
 import { auth } from "@/auth";
 import { db } from "@/lib/db";
+import { LIMITS, overLimit } from "@/lib/validation";
 import { revalidatePath } from "next/cache";
 import type { HighlightLabel } from "@prisma/client";
 
@@ -30,6 +31,12 @@ export async function createHighlight(
 
   if (!input.sourceId) return { error: "Source ID is required." };
   if (!input.quoteText?.trim()) return { error: "Quote text is required." };
+  if (overLimit(input.quoteText, LIMITS.highlightQuote))
+    return { error: "Selected quote is too long to save." };
+  if (overLimit(input.annotation, LIMITS.highlightAnnotation))
+    return {
+      error: `Annotation must be under ${LIMITS.highlightAnnotation} characters.`,
+    };
   if (input.startOffset < 0) return { error: "Invalid start offset." };
   if (input.endOffset <= input.startOffset)
     return { error: "Invalid offset range." };

--- a/src/server/actions/sources.ts
+++ b/src/server/actions/sources.ts
@@ -2,6 +2,7 @@
 
 import { auth } from "@/auth";
 import { db } from "@/lib/db";
+import { LIMITS, overLimit } from "@/lib/validation";
 import { revalidatePath } from "next/cache";
 import type { SourceType, SourceStatus } from "@prisma/client";
 
@@ -56,11 +57,32 @@ function validateTypeSpecificFields(
   return null;
 }
 
+function validateLengths(
+  input: Partial<Omit<SourceInput, "dossierId">>,
+): string | null {
+  if (overLimit(input.title, LIMITS.sourceTitle))
+    return `Title must be under ${LIMITS.sourceTitle} characters.`;
+  if (overLimit(input.url, LIMITS.sourceUrl))
+    return `URL must be under ${LIMITS.sourceUrl} characters.`;
+  if (overLimit(input.author, LIMITS.sourceAuthor))
+    return `Author must be under ${LIMITS.sourceAuthor} characters.`;
+  if (overLimit(input.publisher, LIMITS.sourcePublisher))
+    return `Publisher must be under ${LIMITS.sourcePublisher} characters.`;
+  if (overLimit(input.summary, LIMITS.sourceSummary))
+    return `Summary must be under ${LIMITS.sourceSummary} characters.`;
+  if (overLimit(input.rawText, LIMITS.sourceRawText))
+    return "Source content is too long.";
+  return null;
+}
+
 function validateSourceInput(
   input: SourceInput,
 ): string | null {
   if (!input.dossierId) return "Dossier ID is required.";
   if (!input.title?.trim()) return "Title is required.";
+
+  const lengthError = validateLengths(input);
+  if (lengthError) return lengthError;
 
   if (!VALID_SOURCE_TYPES.includes(input.type)) {
     return `Invalid source type. Must be one of: ${VALID_SOURCE_TYPES.join(", ")}.`;
@@ -201,6 +223,9 @@ export async function updateSource(
   if (input.title !== undefined && !input.title?.trim()) {
     return { error: "Title is required." };
   }
+
+  const lengthError = validateLengths(input);
+  if (lengthError) return { error: lengthError };
 
   if (input.credibilityRating != null) {
     if (


### PR DESCRIPTION
## Summary

- Centralized field-length limits in a new `src/lib/validation.ts` and applied them across brief, claim, dossier, entity, event, highlight, source, and search inputs so over-long payloads fail with clear messages instead of 500s.
- Converted the claim inline editor to debounced autosave with a live save indicator, a `beforeunload` warning for unsaved edits, and confirm-before-close when a save is mid-flight or errored.
- Surfaced claim status/delete/autosave errors in an accessible banner instead of swallowing them silently.
- Hardened `/api/search` with query-length validation, try/catch, and a 500 fallback; mirrored the same guardrails on the `/search` page with a user-visible error state when workspace search fails.

`★ Insight ─────────────────────────────────────`
- Centralizing validation constants in one module (`src/lib/validation.ts`) keeps server actions and API routes in lockstep — a single source of truth prevents drift between the claim editor's client-side limits and what the server will accept.
- Debounced autosave + `beforeunload` + confirm-on-close forms a three-layer safety net: the debounce reduces write pressure, the browser warning covers accidental tab closes, and the in-app confirm handles the in-flight edge case where the debounce hasn't flushed yet.
- Error banners (vs. silent catches or toasts) are the right call for autosave flows because users need persistent, accessible feedback that their work didn't save — a toast that auto-dismisses would defeat the purpose.
`─────────────────────────────────────────────────`

Closes #27

## Validation

- [x] Code builds successfully
- [x] Lint passes
- [x] Typecheck passes
- [ ] Tests pass (if applicable)
- [ ] Matches design direction from product spec
