### PR TITLE
refactor(DOS-FIX): UI polish pass — overview data, StatusChip, EmptyState, tokens

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -517,7 +517,7 @@ We are confident in the compliance posture of our manufacturing network as we en
         "FDA investigators conducted an unannounced CGMP inspection of Northgate's Raleigh sterile fill facility, spanning 13 business days.",
       event_date: new Date("2023-10-16"),
       precision: "day",
-      confidence: 5,
+      confidence: 95,
       claim_id: claimSystemic.id,
       highlights: { create: [{ highlight_id: hl2.id }] },
       entities: {
@@ -537,7 +537,7 @@ We are confident in the compliance posture of our manufacturing network as we en
         "FDA formally issued warning letter citing three CGMP violations, including 47 instances of audit log backdating.",
       event_date: new Date("2024-01-08"),
       precision: "day",
-      confidence: 5,
+      confidence: 98,
       claim_id: claimSystemic.id,
       highlights: { create: [{ highlight_id: hl1.id }] },
       entities: {
@@ -560,7 +560,7 @@ We are confident in the compliance posture of our manufacturing network as we en
         "VP of QA Raymond Chu formally escalated data integrity concerns in writing to CSO Dr. Sandra Wei and CEO David Harrington, requesting a CAPA within 30 days.",
       event_date: new Date("2022-06-14"),
       precision: "day",
-      confidence: 5,
+      confidence: 88,
       claim_id: claimKnowledge.id,
       highlights: {
         create: [{ highlight_id: hl4.id }, { highlight_id: hl5.id }],
@@ -582,7 +582,7 @@ We are confident in the compliance posture of our manufacturing network as we en
         "David Harrington's 2023 annual shareholder letter characterizes the Raleigh facility as operating under an industry-leading quality culture — a claim issued 12 months after Chu's internal escalation.",
       event_date: new Date("2023-03-22"),
       precision: "day",
-      confidence: 4,
+      confidence: 75,
       claim_id: claimKnowledge.id,
       entities: {
         create: [

--- a/src/app/dossiers/[id]/layout.tsx
+++ b/src/app/dossiers/[id]/layout.tsx
@@ -6,6 +6,7 @@ import { WorkspaceTabBar } from "@/components/dossiers/WorkspaceTabBar";
 import { WorkspacePaneTransition } from "@/components/dossiers/WorkspacePaneTransition";
 import { GlobalSearchBar } from "@/components/search/GlobalSearchBar";
 import { DossierWorkspaceShortcuts } from "@/components/command/DossierWorkspaceShortcuts";
+import { StatusChip } from "@/components/ui/StatusChip";
 
 interface DossierLayoutProps {
   children: React.ReactNode;
@@ -81,10 +82,8 @@ export default async function DossierLayout({
             {dossier.title}
           </h1>
 
-          <span
-            className="chip shrink-0"
-          >
-            {dossier.status}
+          <span className="shrink-0">
+            <StatusChip status={dossier.status} />
           </span>
         </div>
 

--- a/src/app/dossiers/[id]/overview/page.tsx
+++ b/src/app/dossiers/[id]/overview/page.tsx
@@ -1,10 +1,64 @@
 import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { auth } from "@/auth";
+import { getDossier } from "@/server/queries/dossiers";
+import {
+  getOpenClaims,
+  getRecentHighlights,
+  getTimelinePreview,
+  getTopEntitiesByMentions,
+  type OverviewClaim,
+  type OverviewEntity,
+  type OverviewEvent,
+  type OverviewHighlight,
+} from "@/server/queries/overview";
+import { EmptyState } from "@/components/ui/EmptyState";
 
 export const metadata: Metadata = {
   title: "Overview — Dossier",
 };
 
-export default function OverviewPage() {
+interface OverviewPageProps {
+  params: Promise<{ id: string }>;
+}
+
+const CLAIM_STATUS_LABELS: Record<string, string> = {
+  open: "Open",
+  supported: "Supported",
+  contested: "Contested",
+  deprecated: "Deprecated",
+};
+
+const CLAIM_STATUS_CHIP: Record<string, string> = {
+  open: "chip",
+  supported: "chip chip-success",
+  contested: "chip chip-alert",
+  deprecated: "chip chip-warning",
+};
+
+export default async function OverviewPage({ params }: OverviewPageProps) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    redirect("/login");
+  }
+
+  const { id } = await params;
+  const dossier = await getDossier(id, session.user.id);
+  if (!dossier) {
+    notFound();
+  }
+
+  const [highlights, entities, events, claims] = await Promise.all([
+    getRecentHighlights(id, session.user.id, 5),
+    getTopEntitiesByMentions(id, session.user.id, 5),
+    getTimelinePreview(id, session.user.id, 4),
+    getOpenClaims(id, session.user.id, 5),
+  ]);
+
+  const summary = dossier.summary?.trim();
+  const researchGoal = dossier.research_goal?.trim();
+
   return (
     <div
       className="w-full max-w-[960px] mx-auto py-8"
@@ -13,84 +67,381 @@ export default function OverviewPage() {
       <div className="grid grid-cols-2 gap-4 mb-4 anim-stagger">
         {/* Summary panel */}
         <div className="panel col-span-full p-6">
-          <p
-            className="mb-2"
-            style={{
-              fontFamily: "var(--font-mono)",
-              fontSize: "0.6875rem",
-              textTransform: "uppercase",
-              letterSpacing: "0.08em",
-              color: "var(--color-ink-secondary)",
-            }}
-          >
-            Research Summary
-          </p>
-          <p
-            style={{
-              fontFamily: "var(--font-sans)",
-              fontSize: "0.9375rem",
-              color: "var(--color-ink-secondary)",
-              fontStyle: "italic",
-            }}
-          >
-            No summary yet. Add sources and claims to build your research picture.
-          </p>
+          <PanelEyebrow>Research Summary</PanelEyebrow>
+          {summary || researchGoal ? (
+            <div>
+              {summary && (
+                <p
+                  style={{
+                    fontFamily: "var(--font-sans)",
+                    fontSize: "0.9375rem",
+                    color: "var(--color-ink-primary)",
+                    lineHeight: 1.55,
+                    maxWidth: "none",
+                  }}
+                >
+                  {summary}
+                </p>
+              )}
+              {researchGoal && (
+                <p
+                  style={{
+                    fontFamily: "var(--font-sans)",
+                    fontSize: "0.8125rem",
+                    color: "var(--color-ink-secondary)",
+                    fontStyle: "italic",
+                    marginTop: summary ? "0.625rem" : 0,
+                    maxWidth: "none",
+                  }}
+                >
+                  {researchGoal}
+                </p>
+              )}
+            </div>
+          ) : (
+            <p
+              style={{
+                fontFamily: "var(--font-sans)",
+                fontSize: "0.9375rem",
+                color: "var(--color-ink-secondary)",
+                fontStyle: "italic",
+              }}
+            >
+              No summary yet. Add sources and claims to build your research picture.
+            </p>
+          )}
         </div>
 
-        {/* Recent evidence */}
-        <EmptyCard
-          label="Recent Evidence"
-          message="Highlights from sources will surface here as you review."
-        />
+        <OverviewPanel label="Recent Evidence">
+          {highlights.length === 0 ? (
+            <EmptyState
+              compact
+              eyebrow="No evidence captured."
+              message="Highlights from sources will surface here as you review."
+            />
+          ) : (
+            <HighlightList dossierId={id} highlights={highlights} />
+          )}
+        </OverviewPanel>
 
-        {/* Top entities */}
-        <EmptyCard
-          label="Key Entities"
-          message="People, organizations, and topics will appear as they are identified."
-        />
+        <OverviewPanel label="Key Entities">
+          {entities.length === 0 ? (
+            <EmptyState
+              compact
+              eyebrow="No entities yet."
+              message="People, organizations, and topics will appear as they are identified."
+            />
+          ) : (
+            <EntityList dossierId={id} entities={entities} />
+          )}
+        </OverviewPanel>
 
-        {/* Timeline preview */}
-        <EmptyCard
-          label="Timeline"
-          message="Dated events will populate a timeline preview here."
-        />
+        <OverviewPanel label="Timeline">
+          {events.length === 0 ? (
+            <EmptyState
+              compact
+              eyebrow="No events on the timeline."
+              message="Dated events will populate a timeline preview here."
+            />
+          ) : (
+            <EventList dossierId={id} events={events} />
+          )}
+        </OverviewPanel>
 
-        {/* Open questions */}
-        <EmptyCard
-          label="Open Claims"
-          message="Claims awaiting evidence will be surfaced here for follow-up."
-        />
+        <OverviewPanel label="Open Claims">
+          {claims.length === 0 ? (
+            <EmptyState
+              compact
+              eyebrow="No open claims."
+              message="Claims awaiting evidence will be surfaced here for follow-up."
+            />
+          ) : (
+            <ClaimList dossierId={id} claims={claims} />
+          )}
+        </OverviewPanel>
       </div>
     </div>
   );
 }
 
-function EmptyCard({ label, message }: { label: string; message: string }) {
+function OverviewPanel({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
   return (
     <div className="panel py-5 px-6">
-      <p
-        className="mb-3"
-        style={{
-          fontFamily: "var(--font-mono)",
-          fontSize: "0.6875rem",
-          textTransform: "uppercase",
-          letterSpacing: "0.08em",
-          color: "var(--color-ink-secondary)",
-        }}
-      >
-        {label}
-      </p>
-      <p
-        className="max-w-none"
-        style={{
-          fontFamily: "var(--font-sans)",
-          fontSize: "0.875rem",
-          color: "var(--color-ink-secondary)",
-          fontStyle: "italic",
-        }}
-      >
-        {message}
-      </p>
+      <PanelEyebrow>{label}</PanelEyebrow>
+      {children}
     </div>
   );
+}
+
+function PanelEyebrow({ children }: { children: React.ReactNode }) {
+  return (
+    <p
+      className="mb-3"
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: "0.6875rem",
+        textTransform: "uppercase",
+        letterSpacing: "0.08em",
+        color: "var(--color-ink-secondary)",
+      }}
+    >
+      {children}
+    </p>
+  );
+}
+
+function HighlightList({
+  dossierId,
+  highlights,
+}: {
+  dossierId: string;
+  highlights: OverviewHighlight[];
+}) {
+  return (
+    <ul
+      style={{ listStyle: "none", display: "grid", gap: "0.625rem" }}
+      className="anim-stagger"
+    >
+      {highlights.map((hl) => (
+        <li key={hl.id}>
+          <Link
+            href={`/dossiers/${dossierId}/sources/${hl.source.id}#highlight-${hl.id}`}
+            className="dossier-row-link"
+            style={{
+              display: "block",
+              padding: "0.5rem 0.625rem",
+              borderRadius: "var(--radius-sm)",
+              textDecoration: "none",
+            }}
+          >
+            <p
+              style={{
+                fontFamily: "var(--font-sans)",
+                fontSize: "0.8125rem",
+                color: "var(--color-ink-primary)",
+                lineHeight: 1.5,
+                maxWidth: "none",
+                display: "-webkit-box",
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: "vertical",
+                overflow: "hidden",
+              }}
+            >
+              “{hl.quote_text}”
+            </p>
+            <p
+              style={{
+                marginTop: "0.25rem",
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.6875rem",
+                color: "var(--color-ink-secondary)",
+                letterSpacing: "0.03em",
+                maxWidth: "none",
+              }}
+            >
+              {hl.source.title}
+            </p>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function EntityList({
+  dossierId,
+  entities,
+}: {
+  dossierId: string;
+  entities: OverviewEntity[];
+}) {
+  return (
+    <ul style={{ listStyle: "none", display: "grid", gap: "0.5rem" }}>
+      {entities.map((entity) => (
+        <li key={entity.id}>
+          <Link
+            href={`/dossiers/${dossierId}/entities#entity-${entity.id}`}
+            className="dossier-row-link"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: "0.75rem",
+              padding: "0.375rem 0.625rem",
+              borderRadius: "var(--radius-sm)",
+              textDecoration: "none",
+            }}
+          >
+            <span
+              style={{
+                fontFamily: "var(--font-sans)",
+                fontSize: "0.875rem",
+                color: "var(--color-ink-primary)",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {entity.name}
+            </span>
+            <span
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: "0.5rem",
+                flexShrink: 0,
+              }}
+            >
+              <span className="chip">{entity.type}</span>
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "0.6875rem",
+                  color: "var(--color-ink-secondary)",
+                }}
+              >
+                {entity._count.mentions} mention
+                {entity._count.mentions === 1 ? "" : "s"}
+              </span>
+            </span>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function EventList({
+  dossierId,
+  events,
+}: {
+  dossierId: string;
+  events: OverviewEvent[];
+}) {
+  return (
+    <ul style={{ listStyle: "none", display: "grid", gap: "0.5rem" }}>
+      {events.map((event) => (
+        <li key={event.id}>
+          <Link
+            href={`/dossiers/${dossierId}/timeline#event-${event.id}`}
+            className="dossier-row-link"
+            style={{
+              display: "flex",
+              alignItems: "baseline",
+              justifyContent: "space-between",
+              gap: "0.75rem",
+              padding: "0.375rem 0.625rem",
+              borderRadius: "var(--radius-sm)",
+              textDecoration: "none",
+            }}
+          >
+            <span
+              style={{
+                fontFamily: "var(--font-sans)",
+                fontSize: "0.875rem",
+                color: "var(--color-ink-primary)",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {event.title}
+            </span>
+            <span
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.6875rem",
+                color: "var(--color-ink-secondary)",
+                flexShrink: 0,
+              }}
+            >
+              {formatEventDate(event.event_date, event.precision)}
+            </span>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ClaimList({
+  dossierId,
+  claims,
+}: {
+  dossierId: string;
+  claims: OverviewClaim[];
+}) {
+  return (
+    <ul style={{ listStyle: "none", display: "grid", gap: "0.5rem" }}>
+      {claims.map((claim) => (
+        <li key={claim.id}>
+          <Link
+            href={`/dossiers/${dossierId}/claims#claim-${claim.id}`}
+            className="dossier-row-link"
+            style={{
+              display: "flex",
+              alignItems: "flex-start",
+              justifyContent: "space-between",
+              gap: "0.75rem",
+              padding: "0.5rem 0.625rem",
+              borderRadius: "var(--radius-sm)",
+              textDecoration: "none",
+            }}
+          >
+            <span
+              style={{
+                fontFamily: "var(--font-sans)",
+                fontSize: "0.8125rem",
+                color: "var(--color-ink-primary)",
+                lineHeight: 1.45,
+                maxWidth: "none",
+                display: "-webkit-box",
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: "vertical",
+                overflow: "hidden",
+              }}
+            >
+              {claim.statement}
+            </span>
+            <span
+              className={CLAIM_STATUS_CHIP[claim.status] ?? "chip"}
+              style={{ flexShrink: 0, marginTop: "0.0625rem" }}
+            >
+              {CLAIM_STATUS_LABELS[claim.status] ?? claim.status}
+            </span>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function formatEventDate(
+  date: Date | null,
+  precision: OverviewEvent["precision"],
+): string {
+  if (!date) return "—";
+  const d = new Date(date);
+  if (precision === "year") {
+    return d.getUTCFullYear().toString();
+  }
+  if (precision === "month") {
+    return d.toLocaleDateString("en-US", {
+      month: "short",
+      year: "numeric",
+      timeZone: "UTC",
+    });
+  }
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -32,6 +32,26 @@
   --color-error-bg: #f0dede;
   --color-error-border: #d4a8a8;
 
+  /* Interactive hover shades — slightly deeper than the base tokens */
+  --color-accent-ink-hover: #1a5c8a;
+  --color-border-hover: #c0b8a8;
+
+  /* Chip variants — paired bg/border/fg per semantic status */
+  --color-chip-citation-border: #b8d3ea;
+  --color-chip-citation-fg: var(--color-accent-ink);
+
+  --color-chip-success-bg: #d8f0e6;
+  --color-chip-success-border: #9dd4be;
+  --color-chip-success-fg: var(--color-accent-success);
+
+  --color-chip-alert-bg: #f0dede;
+  --color-chip-alert-border: #d4a8a8;
+  --color-chip-alert-fg: var(--color-accent-alert);
+
+  --color-chip-warning-bg: #f5ead8;
+  --color-chip-warning-border: #d4bd8c;
+  --color-chip-warning-fg: var(--color-accent-warning);
+
   /* Border radius */
   --radius-xs: 2px;
   --radius-sm: 4px;
@@ -178,20 +198,19 @@ dialog::backdrop {
 }
 
 .btn-primary:hover {
-  background-color: #1a5c8a;
-  border-color: #1a5c8a;
+  background-color: var(--color-accent-ink-hover);
+  border-color: var(--color-accent-ink-hover);
 }
 
 .btn-secondary {
-  background-color: transparent;
+  background-color: var(--color-bg-panel);
   color: var(--color-ink-primary);
   border-color: var(--color-border);
-  background-color: var(--color-bg-panel);
 }
 
 .btn-secondary:hover {
   background-color: var(--color-bg-selected);
-  border-color: #c0b8a8;
+  border-color: var(--color-border-hover);
 }
 
 .btn-ghost {
@@ -305,26 +324,26 @@ textarea.input {
 
 .chip-citation {
   background-color: var(--color-chip-citation);
-  border-color: #b8d3ea;
-  color: var(--color-accent-ink);
+  border-color: var(--color-chip-citation-border);
+  color: var(--color-chip-citation-fg);
 }
 
 .chip-success {
-  background-color: #d8f0e6;
-  border-color: #9dd4be;
-  color: var(--color-accent-success);
+  background-color: var(--color-chip-success-bg);
+  border-color: var(--color-chip-success-border);
+  color: var(--color-chip-success-fg);
 }
 
 .chip-alert {
-  background-color: #f0dede;
-  border-color: #d4a8a8;
-  color: var(--color-accent-alert);
+  background-color: var(--color-chip-alert-bg);
+  border-color: var(--color-chip-alert-border);
+  color: var(--color-chip-alert-fg);
 }
 
 .chip-warning {
-  background-color: #f5ead8;
-  border-color: #d4bd8c;
-  color: var(--color-accent-warning);
+  background-color: var(--color-chip-warning-bg);
+  border-color: var(--color-chip-warning-border);
+  color: var(--color-chip-warning-fg);
 }
 
 /* ------ Tables ------ */

--- a/src/components/claims/ClaimsClient.tsx
+++ b/src/components/claims/ClaimsClient.tsx
@@ -557,11 +557,11 @@ function ClaimCard({
               style={{
                 fontSize: "0.6875rem",
                 padding: "0.25rem 0.375rem",
-                color: "var(--color-ink-secondary)",
+                color: "var(--color-accent-alert)",
               }}
               aria-label="Delete claim"
             >
-              ✕
+              Delete
             </button>
           </div>
         </div>

--- a/src/components/dossiers/DossiersClient.tsx
+++ b/src/components/dossiers/DossiersClient.tsx
@@ -31,6 +31,7 @@ export function DossiersClient({ dossiers }: DossiersClientProps) {
     <>
       <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: "1.25rem" }}>
         <button
+          type="button"
           className="btn btn-primary"
           onClick={() => setModalOpen(true)}
         >

--- a/src/components/dossiers/DossiersClient.tsx
+++ b/src/components/dossiers/DossiersClient.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { NewDossierModal } from "./NewDossierModal";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { StatusChip } from "@/components/ui/StatusChip";
 import type { DossierListItem } from "@/server/queries/dossiers";
 
@@ -38,17 +39,10 @@ export function DossiersClient({ dossiers }: DossiersClientProps) {
       </div>
 
       {dossiers.length === 0 ? (
-        <div className="panel" style={{ padding: "3rem 2rem", textAlign: "center" }}>
-          <p
-            style={{
-              fontFamily: "var(--font-mono)",
-              fontSize: "0.8125rem",
-              color: "var(--color-ink-secondary)",
-            }}
-          >
-            No dossiers yet. Create one to start building your research workspace.
-          </p>
-        </div>
+        <EmptyState
+          eyebrow="No dossiers yet."
+          message="Create one to start building your research workspace."
+        />
       ) : (
         <div
           className="panel"

--- a/src/components/dossiers/DossiersClient.tsx
+++ b/src/components/dossiers/DossiersClient.tsx
@@ -4,17 +4,12 @@ import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { NewDossierModal } from "./NewDossierModal";
+import { StatusChip } from "@/components/ui/StatusChip";
 import type { DossierListItem } from "@/server/queries/dossiers";
 
 interface DossiersClientProps {
   dossiers: DossierListItem[];
 }
-
-const STATUS_LABEL: Record<string, string> = {
-  active: "Active",
-  archived: "Archived",
-  on_hold: "On hold",
-};
 
 export function DossiersClient({ dossiers }: DossiersClientProps) {
   const [modalOpen, setModalOpen] = useState(false);
@@ -127,27 +122,7 @@ export function DossiersClient({ dossiers }: DossiersClientProps) {
                   {dossier._count.sources} source
                   {dossier._count.sources !== 1 ? "s" : ""}
                 </span>
-                <span
-                  style={{
-                    fontFamily: "var(--font-mono)",
-                    fontSize: "0.6875rem",
-                    color:
-                      dossier.status === "active"
-                        ? "var(--color-accent-success)"
-                        : "var(--color-ink-secondary)",
-                    backgroundColor:
-                      dossier.status === "active"
-                        ? "rgba(45, 106, 79, 0.1)"
-                        : "var(--color-bg-selected)",
-                    padding: "0.125rem 0.5rem",
-                    borderRadius: "var(--radius-xs)",
-                    border: "var(--border-hairline) solid var(--color-border)",
-                    textTransform: "uppercase",
-                    letterSpacing: "0.06em",
-                  }}
-                >
-                  {STATUS_LABEL[dossier.status] ?? dossier.status}
-                </span>
+                <StatusChip status={dossier.status} />
               </div>
             </Link>
           ))}

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { EmptyState } from "@/components/ui/EmptyState";
 import type {
   SearchObjectType,
   SearchResultBase,
@@ -32,6 +33,7 @@ export function SearchResults({ results, dossierTitle }: SearchResultsProps) {
   if (!results.query) {
     return (
       <EmptyState
+        eyebrow="Search the workspace."
         message="Enter a term to search across dossiers, sources, highlights, claims, entities, and briefs."
       />
     );
@@ -40,10 +42,11 @@ export function SearchResults({ results, dossierTitle }: SearchResultsProps) {
   if (results.total === 0) {
     return (
       <EmptyState
+        eyebrow="No matches."
         message={
           dossierTitle
-            ? `No matches for “${results.query}” in ${dossierTitle}.`
-            : `No matches for “${results.query}”.`
+            ? `Nothing matched “${results.query}” in ${dossierTitle}.`
+            : `Nothing matched “${results.query}”.`
         }
       />
     );
@@ -167,25 +170,6 @@ function ResultGroup({
         ))}
       </div>
     </section>
-  );
-}
-
-function EmptyState({ message }: { message: string }) {
-  return (
-    <div
-      className="panel"
-      style={{ padding: "2.5rem 2rem", textAlign: "center" }}
-    >
-      <p
-        style={{
-          fontFamily: "var(--font-mono)",
-          fontSize: "0.8125rem",
-          color: "var(--color-ink-secondary)",
-        }}
-      >
-        {message}
-      </p>
-    </div>
   );
 }
 

--- a/src/components/ui/StatusChip.tsx
+++ b/src/components/ui/StatusChip.tsx
@@ -1,0 +1,43 @@
+import type { DossierStatus } from "@prisma/client";
+
+/**
+ * STATUS_LABEL maps raw DossierStatus enum values to their user-facing
+ * labels. Exported so callers can display the same phrasing elsewhere
+ * (e.g. filter dropdowns) without repeating the mapping.
+ */
+export const STATUS_LABEL: Record<DossierStatus, string> = {
+  active: "Active",
+  archived: "Archived",
+  on_hold: "On hold",
+};
+
+const STATUS_CHIP_CLASS: Record<DossierStatus, string> = {
+  active: "chip chip-success",
+  on_hold: "chip chip-warning",
+  archived: "chip",
+};
+
+interface StatusChipProps {
+  status: DossierStatus;
+}
+
+/**
+ * StatusChip — canonical dossier status pill.
+ *
+ * Uses the shared .chip* token set and an editorial uppercase tracking
+ * pattern so the badge reads as quiet metadata in the header and the
+ * dossiers index alike.
+ */
+export function StatusChip({ status }: StatusChipProps) {
+  return (
+    <span
+      className={STATUS_CHIP_CLASS[status] ?? "chip"}
+      style={{
+        textTransform: "uppercase",
+        letterSpacing: "0.06em",
+      }}
+    >
+      {STATUS_LABEL[status] ?? status}
+    </span>
+  );
+}

--- a/src/server/queries/overview.ts
+++ b/src/server/queries/overview.ts
@@ -1,0 +1,140 @@
+import { db } from "@/lib/db";
+
+/**
+ * Overview query helpers — cheap, read-only selects that power the
+ * dossier Overview tab panels. Each helper is scoped to the owning user
+ * so RLS-style isolation is enforced at the query layer.
+ */
+
+export async function getRecentHighlights(
+  dossierId: string,
+  userId: string,
+  limit = 5,
+) {
+  return db.highlight.findMany({
+    where: {
+      source: {
+        dossier_id: dossierId,
+        dossier: { owner_id: userId },
+      },
+    },
+    orderBy: { created_at: "desc" },
+    take: limit,
+    select: {
+      id: true,
+      quote_text: true,
+      label: true,
+      created_at: true,
+      source: {
+        select: {
+          id: true,
+          title: true,
+        },
+      },
+    },
+  });
+}
+
+export type OverviewHighlight = Awaited<
+  ReturnType<typeof getRecentHighlights>
+>[number];
+
+export async function getTopEntitiesByMentions(
+  dossierId: string,
+  userId: string,
+  limit = 5,
+) {
+  const entities = await db.entity.findMany({
+    where: {
+      dossier_id: dossierId,
+      dossier: { owner_id: userId },
+    },
+    select: {
+      id: true,
+      name: true,
+      type: true,
+      _count: {
+        select: { mentions: true },
+      },
+    },
+  });
+
+  return entities
+    .sort((a, b) => b._count.mentions - a._count.mentions)
+    .slice(0, limit);
+}
+
+export type OverviewEntity = Awaited<
+  ReturnType<typeof getTopEntitiesByMentions>
+>[number];
+
+export async function getTimelinePreview(
+  dossierId: string,
+  userId: string,
+  limit = 4,
+) {
+  const now = new Date();
+  const upcoming = await db.event.findMany({
+    where: {
+      dossier_id: dossierId,
+      dossier: { owner_id: userId },
+      event_date: { gte: now },
+    },
+    orderBy: { event_date: "asc" },
+    take: limit,
+    select: {
+      id: true,
+      title: true,
+      event_date: true,
+      precision: true,
+    },
+  });
+
+  if (upcoming.length >= limit) return upcoming;
+
+  const recent = await db.event.findMany({
+    where: {
+      dossier_id: dossierId,
+      dossier: { owner_id: userId },
+      event_date: { lt: now },
+    },
+    orderBy: { event_date: "desc" },
+    take: limit - upcoming.length,
+    select: {
+      id: true,
+      title: true,
+      event_date: true,
+      precision: true,
+    },
+  });
+
+  return [...upcoming, ...recent];
+}
+
+export type OverviewEvent = Awaited<
+  ReturnType<typeof getTimelinePreview>
+>[number];
+
+export async function getOpenClaims(
+  dossierId: string,
+  userId: string,
+  limit = 5,
+) {
+  return db.claim.findMany({
+    where: {
+      dossier_id: dossierId,
+      dossier: { owner_id: userId },
+      status: { in: ["open", "contested"] },
+    },
+    orderBy: { updated_at: "desc" },
+    take: limit,
+    select: {
+      id: true,
+      statement: true,
+      status: true,
+      confidence: true,
+    },
+  });
+}
+
+export type OverviewClaim = Awaited<ReturnType<typeof getOpenClaims>>[number];


### PR DESCRIPTION
## Summary

Six focused commits that close a handful of post-MVP UI polish gaps surfaced by a code + screenshot audit. No new features; scope is strictly cleanup and consistency.

- **fix(DOS-FIX): seed confidence as 0-100 integers** — event confidences were seeded on a legacy 1-5 scale (`4`, `5`) while the schema and claim UI treat confidence as a 0-100 percentage. Bumped the four event values to sensible 0-100 integers.
- **fix(DOS-FIX): render dossier overview from dossier data** — the overview tab was a static placeholder that ignored route params. Now an async server component that surfaces the dossier summary/goal, top 5 recent highlights, top 5 entities by mention count, up to 4 upcoming/recent events, and up to 5 open/contested claims. Query helpers live in `src/server/queries/overview.ts`.
- **refactor(DOS-FIX): extract StatusChip and unify status rendering** — two drifted status-chip impls (inline rgba on the dossier list, plain `.chip` with raw enum in the header) now share a single `StatusChip` primitive backed by the chip tokens.
- **refactor(DOS-FIX): consolidate empty states on the EmptyState primitive** — removed parallel empty-state renderings in `SearchResults` and `DossiersClient`; both now use the shared `EmptyState` (with its existing `eyebrow` + italic body API).
- **refactor(DOS-FIX): normalize row actions on claims** — the destructive `✕` glyph on claim rows becomes a text `Delete` styled with `--color-accent-alert`, matching the Entities row pattern. `aria-label="Delete claim"` preserved.
- **style(DOS-FIX): move hover/chip colors to tokens, clean up globals.css** — new paired chip tokens and hover tokens in `@theme`; button hover styles and all four chip variants reference `var()` instead of inline hex. Dead `background-color: transparent` in `.btn-secondary` removed. Missing `type="button"` added to the New Dossier trigger.

## Validation

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm run test` — 202 passed
- [x] `npx prisma db seed` — reseeded demo data after commit 1
- [ ] Visual verification in dev server — pending reviewer spot-check (overview panels, dossier list/header status chip parity, claims row Delete button, search empty state)